### PR TITLE
Update stage 2 & 3 solutions

### DIFF
--- a/.github/workflows/post-diffs-in-pr.yml
+++ b/.github/workflows/post-diffs-in-pr.yml
@@ -1,0 +1,14 @@
+name: Post diffs
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  post_diffs:
+    uses: codecrafters-io/course-sdk/.github/workflows/post-diffs-in-pr.yml@nikandfor/post_diffs_in_pr
+    with:
+      sdkRef: nikandfor/post_diffs_in_pr

--- a/solutions/go/concurrent-clients/code/app/server.go
+++ b/solutions/go/concurrent-clients/code/app/server.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net"

--- a/solutions/go/concurrent-clients/code/app/server.go
+++ b/solutions/go/concurrent-clients/code/app/server.go
@@ -28,11 +28,23 @@ func handleConnection(conn net.Conn) {
 	defer conn.Close()
 
 	for {
-		if _, err := conn.Read([]byte{}); err != nil {
-			fmt.Println("Error reading from client: ", err.Error())
-			continue
+		buf := make([]byte, 1024)
+
+		if _, err := conn.Read(buf); err != nil {
+			if err == io.EOF {
+				continue
+			} else {
+				fmt.Println("error reading from client: ", err.Error())
+				os.Exit(1)
+			}
 		}
 
-		conn.Write([]byte("+PONG\r\n"))
+		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
+		if bytes.Contains(buf, []byte("ping")) {
+			conn.Write([]byte("+PONG\r\n"))
+		} else {
+			fmt.Println("received unknown command:", string(buf))
+			os.Exit(1)
+		}
 	}
 }

--- a/solutions/go/concurrent-clients/code/app/server.go
+++ b/solutions/go/concurrent-clients/code/app/server.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net"
 	"os"
 )

--- a/solutions/go/concurrent-clients/code/app/server.go
+++ b/solutions/go/concurrent-clients/code/app/server.go
@@ -34,7 +34,7 @@ func handleConnection(conn net.Conn) {
 
 		if _, err := conn.Read(buf); err != nil {
 			if err == io.EOF {
-				continue
+				break
 			} else {
 				fmt.Println("error reading from client: ", err.Error())
 				os.Exit(1)

--- a/solutions/go/concurrent-clients/code/app/server.go
+++ b/solutions/go/concurrent-clients/code/app/server.go
@@ -41,12 +41,8 @@ func handleConnection(conn net.Conn) {
 			}
 		}
 
-		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
-		if bytes.Contains(buf, []byte("ping")) {
-			conn.Write([]byte("+PONG\r\n"))
-		} else {
-			fmt.Println("received unknown command:", string(buf))
-			os.Exit(1)
-		}
+		// Let's ignore the client's input for now and hardcode a response.
+		// We'll implement a proper Redis Protocol parser in later stages.
+		conn.Write([]byte("+PONG\r\n"))
 	}
 }

--- a/solutions/go/concurrent-clients/diff/app/server.go.diff
+++ b/solutions/go/concurrent-clients/diff/app/server.go.diff
@@ -1,4 +1,4 @@
-@@ -1,46 +1,52 @@
+@@ -1,42 +1,48 @@
  package main
 
  import (
@@ -46,12 +46,8 @@
  			}
  		}
 
- 		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
- 		if bytes.Contains(buf, []byte("ping")) {
- 			conn.Write([]byte("+PONG\r\n"))
- 		} else {
- 			fmt.Println("received unknown command:", string(buf))
- 			os.Exit(1)
- 		}
+ 		// Let's ignore the client's input for now and hardcode a response.
+ 		// We'll implement a proper Redis Protocol parser in later stages.
+ 		conn.Write([]byte("+PONG\r\n"))
  	}
  }

--- a/solutions/go/concurrent-clients/diff/app/server.go.diff
+++ b/solutions/go/concurrent-clients/diff/app/server.go.diff
@@ -39,7 +39,7 @@
 
  		if _, err := conn.Read(buf); err != nil {
  			if err == io.EOF {
- 				continue
+ 				break
  			} else {
  				fmt.Println("error reading from client: ", err.Error())
  				os.Exit(1)

--- a/solutions/go/concurrent-clients/diff/app/server.go.diff
+++ b/solutions/go/concurrent-clients/diff/app/server.go.diff
@@ -1,8 +1,10 @@
-@@ -1,32 +1,38 @@
+@@ -1,45 +1,38 @@
  package main
 
  import (
+-	"bytes"
  	"fmt"
+-	"io"
  	"net"
  	"os"
  )
@@ -32,12 +34,30 @@
 +func handleConnection(conn net.Conn) {
  	defer conn.Close()
 
- 	for {
- 		if _, err := conn.Read([]byte{}); err != nil {
- 			fmt.Println("Error reading from client: ", err.Error())
- 			continue
- 		}
+-    for {
+-        buf := make([]byte, 1024)
++	for {
++		if _, err := conn.Read([]byte{}); err != nil {
++			fmt.Println("Error reading from client: ", err.Error())
++			continue
++		}
 
- 		conn.Write([]byte("+PONG\r\n"))
- 	}
+-        if _, err := conn.Read(buf); err != nil {
+-            if err == io.EOF {
+-                continue
+-            } else {
+-                fmt.Println("error reading from client: ", err.Error())
+-                os.Exit(1)
+-            }
+-        }
+-
+-        if bytes.Contains(buf, []byte("ping")) {
+-            conn.Write([]byte("+PONG\r\n"))
+-        } else {
+-            fmt.Println("received unknown command:", string(buf))
+-            os.Exit(1)
+-        }
+-    }
++		conn.Write([]byte("+PONG\r\n"))
++	}
  }

--- a/solutions/go/concurrent-clients/diff/app/server.go.diff
+++ b/solutions/go/concurrent-clients/diff/app/server.go.diff
@@ -1,8 +1,7 @@
-@@ -1,42 +1,48 @@
+@@ -1,41 +1,47 @@
  package main
 
  import (
- 	"bytes"
  	"fmt"
  	"io"
  	"net"

--- a/solutions/go/concurrent-clients/diff/app/server.go.diff
+++ b/solutions/go/concurrent-clients/diff/app/server.go.diff
@@ -1,10 +1,10 @@
-@@ -1,46 +1,50 @@
+@@ -1,46 +1,52 @@
  package main
 
  import (
--	"bytes"
+ 	"bytes"
  	"fmt"
--	"io"
+ 	"io"
  	"net"
  	"os"
  )

--- a/solutions/go/concurrent-clients/diff/app/server.go.diff
+++ b/solutions/go/concurrent-clients/diff/app/server.go.diff
@@ -1,4 +1,4 @@
-@@ -1,45 +1,38 @@
+@@ -1,46 +1,50 @@
  package main
 
  import (
@@ -35,26 +35,23 @@
  	defer conn.Close()
 
  	for {
--		buf := make([]byte, 1024)
--
--		if _, err := conn.Read(buf); err != nil {
--			if err == io.EOF {
--				continue
--			} else {
--				fmt.Println("error reading from client: ", err.Error())
--				os.Exit(1)
--			}
-+		if _, err := conn.Read([]byte{}); err != nil {
-+			fmt.Println("Error reading from client: ", err.Error())
-+			continue
+ 		buf := make([]byte, 1024)
+
+ 		if _, err := conn.Read(buf); err != nil {
+ 			if err == io.EOF {
+ 				continue
+ 			} else {
+ 				fmt.Println("error reading from client: ", err.Error())
+ 				os.Exit(1)
+ 			}
  		}
 
--		if bytes.Contains(buf, []byte("ping")) {
--			conn.Write([]byte("+PONG\r\n"))
--		} else {
--			fmt.Println("received unknown command:", string(buf))
--			os.Exit(1)
--		}
-+		conn.Write([]byte("+PONG\r\n"))
+ 		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
+ 		if bytes.Contains(buf, []byte("ping")) {
+ 			conn.Write([]byte("+PONG\r\n"))
+ 		} else {
+ 			fmt.Println("received unknown command:", string(buf))
+ 			os.Exit(1)
+ 		}
  	}
  }

--- a/solutions/go/concurrent-clients/diff/app/server.go.diff
+++ b/solutions/go/concurrent-clients/diff/app/server.go.diff
@@ -34,30 +34,27 @@
 +func handleConnection(conn net.Conn) {
  	defer conn.Close()
 
--    for {
--        buf := make([]byte, 1024)
-+	for {
+ 	for {
+-		buf := make([]byte, 1024)
+-
+-		if _, err := conn.Read(buf); err != nil {
+-			if err == io.EOF {
+-				continue
+-			} else {
+-				fmt.Println("error reading from client: ", err.Error())
+-				os.Exit(1)
+-			}
 +		if _, err := conn.Read([]byte{}); err != nil {
 +			fmt.Println("Error reading from client: ", err.Error())
 +			continue
-+		}
+ 		}
 
--        if _, err := conn.Read(buf); err != nil {
--            if err == io.EOF {
--                continue
--            } else {
--                fmt.Println("error reading from client: ", err.Error())
--                os.Exit(1)
--            }
--        }
--
--        if bytes.Contains(buf, []byte("ping")) {
--            conn.Write([]byte("+PONG\r\n"))
--        } else {
--            fmt.Println("received unknown command:", string(buf))
--            os.Exit(1)
--        }
--    }
+-		if bytes.Contains(buf, []byte("ping")) {
+-			conn.Write([]byte("+PONG\r\n"))
+-		} else {
+-			fmt.Println("received unknown command:", string(buf))
+-			os.Exit(1)
+-		}
 +		conn.Write([]byte("+PONG\r\n"))
-+	}
+ 	}
  }

--- a/solutions/go/echo/diff/app/server.go.diff
+++ b/solutions/go/echo/diff/app/server.go.diff
@@ -1,8 +1,7 @@
-@@ -1,48 +1,50 @@
+@@ -1,47 +1,50 @@
  package main
 
  import (
--	"bytes"
 +	"bufio"
  	"fmt"
 -	"io"

--- a/solutions/go/echo/diff/app/server.go.diff
+++ b/solutions/go/echo/diff/app/server.go.diff
@@ -1,9 +1,11 @@
-@@ -1,50 +1,50 @@
+@@ -1,52 +1,50 @@
  package main
 
  import (
+-	"bytes"
 +	"bufio"
  	"fmt"
+-	"io"
  	"net"
  	"os"
  )

--- a/solutions/go/echo/diff/app/server.go.diff
+++ b/solutions/go/echo/diff/app/server.go.diff
@@ -1,4 +1,4 @@
-@@ -1,38 +1,50 @@
+@@ -1,50 +1,50 @@
  package main
 
  import (
@@ -30,26 +30,36 @@
  	defer conn.Close()
 
  	for {
--		if _, err := conn.Read([]byte{}); err != nil {
--			fmt.Println("Error reading from client: ", err.Error())
--			continue
+-		buf := make([]byte, 1024)
+-
+-		if _, err := conn.Read(buf); err != nil {
+-			if err == io.EOF {
+-				continue
+-			} else {
+-				fmt.Println("error reading from client: ", err.Error())
+-				os.Exit(1)
+-			}
 +		value, err := DecodeRESP(bufio.NewReader(conn))
 +		if err != nil {
 +			fmt.Println("Error decoding RESP: ", err.Error())
 +			return // Ignore clients that we fail to read from
  		}
 
--		conn.Write([]byte("+PONG\r\n"))
+-		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
+-		if bytes.Contains(buf, []byte("ping")) {
 +		command := value.Array()[0].String()
 +		args := value.Array()[1:]
 +
 +		switch command {
 +		case "ping":
-+			conn.Write([]byte("+PONG\r\n"))
+ 			conn.Write([]byte("+PONG\r\n"))
+-		} else {
+-			fmt.Println("received unknown command:", string(buf))
+-			os.Exit(1)
 +		case "echo":
 +			conn.Write([]byte(fmt.Sprintf("$%d\r\n%s\r\n", len(args[0].String()), args[0].String())))
 +		default:
 +			conn.Write([]byte("-ERR unknown command '" + command + "'\r\n"))
-+		}
+ 		}
  	}
  }

--- a/solutions/go/echo/diff/app/server.go.diff
+++ b/solutions/go/echo/diff/app/server.go.diff
@@ -36,7 +36,7 @@
 -
 -		if _, err := conn.Read(buf); err != nil {
 -			if err == io.EOF {
--				continue
+-				break
 -			} else {
 -				fmt.Println("error reading from client: ", err.Error())
 -				os.Exit(1)

--- a/solutions/go/echo/diff/app/server.go.diff
+++ b/solutions/go/echo/diff/app/server.go.diff
@@ -1,4 +1,4 @@
-@@ -1,52 +1,50 @@
+@@ -1,48 +1,50 @@
  package main
 
  import (
@@ -47,21 +47,19 @@
 +			return // Ignore clients that we fail to read from
  		}
 
--		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
--		if bytes.Contains(buf, []byte("ping")) {
+-		// Let's ignore the client's input for now and hardcode a response.
+-		// We'll implement a proper Redis Protocol parser in later stages.
+-		conn.Write([]byte("+PONG\r\n"))
 +		command := value.Array()[0].String()
 +		args := value.Array()[1:]
 +
 +		switch command {
 +		case "ping":
- 			conn.Write([]byte("+PONG\r\n"))
--		} else {
--			fmt.Println("received unknown command:", string(buf))
--			os.Exit(1)
++			conn.Write([]byte("+PONG\r\n"))
 +		case "echo":
 +			conn.Write([]byte(fmt.Sprintf("$%d\r\n%s\r\n", len(args[0].String()), args[0].String())))
 +		default:
 +			conn.Write([]byte("-ERR unknown command '" + command + "'\r\n"))
- 		}
++		}
  	}
  }

--- a/solutions/go/ping-pong-multiple/code/app/server.go
+++ b/solutions/go/ping-pong-multiple/code/app/server.go
@@ -28,7 +28,7 @@ func main() {
 
 		if _, err := conn.Read(buf); err != nil {
 			if err == io.EOF {
-				continue
+				break
 			} else {
 				fmt.Println("error reading from client: ", err.Error())
 				os.Exit(1)

--- a/solutions/go/ping-pong-multiple/code/app/server.go
+++ b/solutions/go/ping-pong-multiple/code/app/server.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net"

--- a/solutions/go/ping-pong-multiple/code/app/server.go
+++ b/solutions/go/ping-pong-multiple/code/app/server.go
@@ -35,12 +35,8 @@ func main() {
 			}
 		}
 
-		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
-		if bytes.Contains(buf, []byte("ping")) {
-			conn.Write([]byte("+PONG\r\n"))
-		} else {
-			fmt.Println("received unknown command:", string(buf))
-			os.Exit(1)
-		}
+		// Let's ignore the client's input for now and hardcode a response.
+		// We'll implement a proper Redis Protocol parser in later stages.
+		conn.Write([]byte("+PONG\r\n"))
 	}
 }

--- a/solutions/go/ping-pong-multiple/code/app/server.go
+++ b/solutions/go/ping-pong-multiple/code/app/server.go
@@ -23,23 +23,23 @@ func main() {
 
 	defer conn.Close()
 
-    for {
-        buf := make([]byte, 1024)
+	for {
+		buf := make([]byte, 1024)
 
-        if _, err := conn.Read(buf); err != nil {
-            if err == io.EOF {
-                continue
-            } else {
-                fmt.Println("error reading from client: ", err.Error())
-                os.Exit(1)
-            }
-        }
+		if _, err := conn.Read(buf); err != nil {
+			if err == io.EOF {
+				continue
+			} else {
+				fmt.Println("error reading from client: ", err.Error())
+				os.Exit(1)
+			}
+		}
 
-        if bytes.Contains(buf, []byte("ping")) {
-            conn.Write([]byte("+PONG\r\n"))
-        } else {
-            fmt.Println("received unknown command:", string(buf))
-            os.Exit(1)
-        }
-    }
+		if bytes.Contains(buf, []byte("ping")) {
+			conn.Write([]byte("+PONG\r\n"))
+		} else {
+			fmt.Println("received unknown command:", string(buf))
+			os.Exit(1)
+		}
+	}
 }

--- a/solutions/go/ping-pong-multiple/code/app/server.go
+++ b/solutions/go/ping-pong-multiple/code/app/server.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net"
 	"os"
 )
@@ -21,12 +23,23 @@ func main() {
 
 	defer conn.Close()
 
-	for {
-		if _, err := conn.Read([]byte{}); err != nil {
-			fmt.Println("Error reading from client: ", err.Error())
-			continue
-		}
+    for {
+        buf := make([]byte, 1024)
 
-		conn.Write([]byte("+PONG\r\n"))
-	}
+        if _, err := conn.Read(buf); err != nil {
+            if err == io.EOF {
+                continue
+            } else {
+                fmt.Println("error reading from client: ", err.Error())
+                os.Exit(1)
+            }
+        }
+
+        if bytes.Contains(buf, []byte("ping")) {
+            conn.Write([]byte("+PONG\r\n"))
+        } else {
+            fmt.Println("received unknown command:", string(buf))
+            os.Exit(1)
+        }
+    }
 }

--- a/solutions/go/ping-pong-multiple/code/app/server.go
+++ b/solutions/go/ping-pong-multiple/code/app/server.go
@@ -35,6 +35,7 @@ func main() {
 			}
 		}
 
+		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
 		if bytes.Contains(buf, []byte("ping")) {
 			conn.Write([]byte("+PONG\r\n"))
 		} else {

--- a/solutions/go/ping-pong-multiple/diff/app/server.go.diff
+++ b/solutions/go/ping-pong-multiple/diff/app/server.go.diff
@@ -1,4 +1,4 @@
-@@ -1,38 +1,45 @@
+@@ -1,39 +1,46 @@
  package main
 
  import (
@@ -33,6 +33,7 @@
 -		os.Exit(1)
 -	}
 -
+-	// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
 -	if bytes.Contains(buf, []byte("ping")) {
 -		conn.Write([]byte("+PONG\r\n"))
 -	} else {
@@ -47,6 +48,7 @@
 +			}
 +		}
 +
++		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
 +		if bytes.Contains(buf, []byte("ping")) {
 +			conn.Write([]byte("+PONG\r\n"))
 +		} else {

--- a/solutions/go/ping-pong-multiple/diff/app/server.go.diff
+++ b/solutions/go/ping-pong-multiple/diff/app/server.go.diff
@@ -1,8 +1,7 @@
-@@ -1,35 +1,42 @@
+@@ -1,34 +1,41 @@
  package main
 
  import (
- 	"bytes"
  	"fmt"
 +	"io"
  	"net"

--- a/solutions/go/ping-pong-multiple/diff/app/server.go.diff
+++ b/solutions/go/ping-pong-multiple/diff/app/server.go.diff
@@ -1,4 +1,4 @@
-@@ -1,39 +1,46 @@
+@@ -1,35 +1,42 @@
  package main
 
  import (
@@ -31,14 +31,6 @@
 -	if _, err := conn.Read(buf); err != nil {
 -		fmt.Println("error reading from client: ", err.Error())
 -		os.Exit(1)
--	}
--
--	// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
--	if bytes.Contains(buf, []byte("ping")) {
--		conn.Write([]byte("+PONG\r\n"))
--	} else {
--		fmt.Println("received unknown command:", string(buf))
--		os.Exit(1)
 +		if _, err := conn.Read(buf); err != nil {
 +			if err == io.EOF {
 +				break
@@ -48,12 +40,12 @@
 +			}
 +		}
 +
-+		// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
-+		if bytes.Contains(buf, []byte("ping")) {
-+			conn.Write([]byte("+PONG\r\n"))
-+		} else {
-+			fmt.Println("received unknown command:", string(buf))
-+			os.Exit(1)
-+		}
++		// Let's ignore the client's input for now and hardcode a response.
++		// We'll implement a proper Redis Protocol parser in later stages.
++		conn.Write([]byte("+PONG\r\n"))
  	}
+-
+-	// Let's ignore the client's input for now and hardcode a response.
+-	// We'll implement a proper Redis Protocol parser in later stages.
+-	conn.Write([]byte("+PONG\r\n"))
  }

--- a/solutions/go/ping-pong-multiple/diff/app/server.go.diff
+++ b/solutions/go/ping-pong-multiple/diff/app/server.go.diff
@@ -24,34 +24,34 @@
 
  	defer conn.Close()
 
--    buf := make([]byte, 1024)
-+    for {
-+        buf := make([]byte, 1024)
+-	buf := make([]byte, 1024)
++	for {
++		buf := make([]byte, 1024)
 
--    if _, err := conn.Read(buf); err != nil {
--        fmt.Println("error reading from client: ", err.Error())
--        os.Exit(1)
--    }
+-	if _, err := conn.Read(buf); err != nil {
+-		fmt.Println("error reading from client: ", err.Error())
+-		os.Exit(1)
+-	}
 -
--    if bytes.Contains(buf, []byte("ping")) {
--        conn.Write([]byte("+PONG\r\n"))
--    } else {
--        fmt.Println("received unknown command:", string(buf))
--        os.Exit(1)
-+        if _, err := conn.Read(buf); err != nil {
-+            if err == io.EOF {
-+                continue
-+            } else {
-+                fmt.Println("error reading from client: ", err.Error())
-+                os.Exit(1)
-+            }
-+        }
+-	if bytes.Contains(buf, []byte("ping")) {
+-		conn.Write([]byte("+PONG\r\n"))
+-	} else {
+-		fmt.Println("received unknown command:", string(buf))
+-		os.Exit(1)
++		if _, err := conn.Read(buf); err != nil {
++			if err == io.EOF {
++				continue
++			} else {
++				fmt.Println("error reading from client: ", err.Error())
++				os.Exit(1)
++			}
++		}
 +
-+        if bytes.Contains(buf, []byte("ping")) {
-+            conn.Write([]byte("+PONG\r\n"))
-+        } else {
-+            fmt.Println("received unknown command:", string(buf))
-+            os.Exit(1)
-+        }
-     }
++		if bytes.Contains(buf, []byte("ping")) {
++			conn.Write([]byte("+PONG\r\n"))
++		} else {
++			fmt.Println("received unknown command:", string(buf))
++			os.Exit(1)
++		}
+ 	}
  }

--- a/solutions/go/ping-pong-multiple/diff/app/server.go.diff
+++ b/solutions/go/ping-pong-multiple/diff/app/server.go.diff
@@ -1,8 +1,10 @@
-@@ -1,25 +1,32 @@
+@@ -1,38 +1,45 @@
  package main
 
  import (
+ 	"bytes"
  	"fmt"
++	"io"
  	"net"
  	"os"
  )
@@ -22,13 +24,34 @@
 
  	defer conn.Close()
 
--	conn.Write([]byte("+PONG\r\n"))
-+	for {
-+		if _, err := conn.Read([]byte{}); err != nil {
-+			fmt.Println("Error reading from client: ", err.Error())
-+			continue
-+		}
+-    buf := make([]byte, 1024)
++    for {
++        buf := make([]byte, 1024)
+
+-    if _, err := conn.Read(buf); err != nil {
+-        fmt.Println("error reading from client: ", err.Error())
+-        os.Exit(1)
+-    }
+-
+-    if bytes.Contains(buf, []byte("ping")) {
+-        conn.Write([]byte("+PONG\r\n"))
+-    } else {
+-        fmt.Println("received unknown command:", string(buf))
+-        os.Exit(1)
++        if _, err := conn.Read(buf); err != nil {
++            if err == io.EOF {
++                continue
++            } else {
++                fmt.Println("error reading from client: ", err.Error())
++                os.Exit(1)
++            }
++        }
 +
-+		conn.Write([]byte("+PONG\r\n"))
-+	}
++        if bytes.Contains(buf, []byte("ping")) {
++            conn.Write([]byte("+PONG\r\n"))
++        } else {
++            fmt.Println("received unknown command:", string(buf))
++            os.Exit(1)
++        }
+     }
  }

--- a/solutions/go/ping-pong-multiple/diff/app/server.go.diff
+++ b/solutions/go/ping-pong-multiple/diff/app/server.go.diff
@@ -41,7 +41,7 @@
 -		os.Exit(1)
 +		if _, err := conn.Read(buf); err != nil {
 +			if err == io.EOF {
-+				continue
++				break
 +			} else {
 +				fmt.Println("error reading from client: ", err.Error())
 +				os.Exit(1)

--- a/solutions/go/ping-pong/code/app/server.go
+++ b/solutions/go/ping-pong/code/app/server.go
@@ -29,6 +29,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
 	if bytes.Contains(buf, []byte("ping")) {
 		conn.Write([]byte("+PONG\r\n"))
 	} else {

--- a/solutions/go/ping-pong/code/app/server.go
+++ b/solutions/go/ping-pong/code/app/server.go
@@ -29,11 +29,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
-	if bytes.Contains(buf, []byte("ping")) {
-		conn.Write([]byte("+PONG\r\n"))
-	} else {
-		fmt.Println("received unknown command:", string(buf))
-		os.Exit(1)
-	}
+	// Let's ignore the client's input for now and hardcode a response.
+	// We'll implement a proper Redis Protocol parser in later stages.
+	conn.Write([]byte("+PONG\r\n"))
 }

--- a/solutions/go/ping-pong/code/app/server.go
+++ b/solutions/go/ping-pong/code/app/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -21,5 +22,17 @@ func main() {
 
 	defer conn.Close()
 
-	conn.Write([]byte("+PONG\r\n"))
+    buf := make([]byte, 1024)
+
+    if _, err := conn.Read(buf); err != nil {
+        fmt.Println("error reading from client: ", err.Error())
+        os.Exit(1)
+    }
+
+    if bytes.Contains(buf, []byte("ping")) {
+        conn.Write([]byte("+PONG\r\n"))
+    } else {
+        fmt.Println("received unknown command:", string(buf))
+        os.Exit(1)
+    }
 }

--- a/solutions/go/ping-pong/code/app/server.go
+++ b/solutions/go/ping-pong/code/app/server.go
@@ -22,17 +22,17 @@ func main() {
 
 	defer conn.Close()
 
-    buf := make([]byte, 1024)
+	buf := make([]byte, 1024)
 
-    if _, err := conn.Read(buf); err != nil {
-        fmt.Println("error reading from client: ", err.Error())
-        os.Exit(1)
-    }
+	if _, err := conn.Read(buf); err != nil {
+		fmt.Println("error reading from client: ", err.Error())
+		os.Exit(1)
+	}
 
-    if bytes.Contains(buf, []byte("ping")) {
-        conn.Write([]byte("+PONG\r\n"))
-    } else {
-        fmt.Println("received unknown command:", string(buf))
-        os.Exit(1)
-    }
+	if bytes.Contains(buf, []byte("ping")) {
+		conn.Write([]byte("+PONG\r\n"))
+	} else {
+		fmt.Println("received unknown command:", string(buf))
+		os.Exit(1)
+	}
 }

--- a/solutions/go/ping-pong/code/app/server.go
+++ b/solutions/go/ping-pong/code/app/server.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"os"

--- a/solutions/go/ping-pong/diff/app/server.go.diff
+++ b/solutions/go/ping-pong/diff/app/server.go.diff
@@ -1,4 +1,4 @@
-@@ -1,20 +1,38 @@
+@@ -1,20 +1,39 @@
  package main
 
  import (
@@ -31,6 +31,7 @@
 +		os.Exit(1)
 +	}
 +
++	// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
 +	if bytes.Contains(buf, []byte("ping")) {
 +		conn.Write([]byte("+PONG\r\n"))
 +	} else {

--- a/solutions/go/ping-pong/diff/app/server.go.diff
+++ b/solutions/go/ping-pong/diff/app/server.go.diff
@@ -1,8 +1,7 @@
-@@ -1,20 +1,35 @@
+@@ -1,20 +1,34 @@
  package main
 
  import (
-+	"bytes"
  	"fmt"
  	"net"
  	"os"

--- a/solutions/go/ping-pong/diff/app/server.go.diff
+++ b/solutions/go/ping-pong/diff/app/server.go.diff
@@ -1,4 +1,4 @@
-@@ -1,20 +1,39 @@
+@@ -1,20 +1,35 @@
  package main
 
  import (
@@ -31,11 +31,7 @@
 +		os.Exit(1)
 +	}
 +
-+	// Let's use a simple substring check for now. We'll implement a proper Redis Protocol parser in later stages.
-+	if bytes.Contains(buf, []byte("ping")) {
-+		conn.Write([]byte("+PONG\r\n"))
-+	} else {
-+		fmt.Println("received unknown command:", string(buf))
-+		os.Exit(1)
-+	}
++	// Let's ignore the client's input for now and hardcode a response.
++	// We'll implement a proper Redis Protocol parser in later stages.
++	conn.Write([]byte("+PONG\r\n"))
  }

--- a/solutions/go/ping-pong/diff/app/server.go.diff
+++ b/solutions/go/ping-pong/diff/app/server.go.diff
@@ -24,17 +24,17 @@
 +
 +	defer conn.Close()
 +
-+    buf := make([]byte, 1024)
++	buf := make([]byte, 1024)
 +
-+    if _, err := conn.Read(buf); err != nil {
-+        fmt.Println("error reading from client: ", err.Error())
-+        os.Exit(1)
-+    }
++	if _, err := conn.Read(buf); err != nil {
++		fmt.Println("error reading from client: ", err.Error())
++		os.Exit(1)
++	}
 +
-+    if bytes.Contains(buf, []byte("ping")) {
-+        conn.Write([]byte("+PONG\r\n"))
-+    } else {
-+        fmt.Println("received unknown command:", string(buf))
-+        os.Exit(1)
-+    }
++	if bytes.Contains(buf, []byte("ping")) {
++		conn.Write([]byte("+PONG\r\n"))
++	} else {
++		fmt.Println("received unknown command:", string(buf))
++		os.Exit(1)
++	}
  }

--- a/solutions/go/ping-pong/diff/app/server.go.diff
+++ b/solutions/go/ping-pong/diff/app/server.go.diff
@@ -1,7 +1,8 @@
-@@ -1,20 +1,25 @@
+@@ -1,20 +1,38 @@
  package main
 
  import (
++	"bytes"
  	"fmt"
  	"net"
  	"os"
@@ -23,5 +24,17 @@
 +
 +	defer conn.Close()
 +
-+	conn.Write([]byte("+PONG\r\n"))
++    buf := make([]byte, 1024)
++
++    if _, err := conn.Read(buf); err != nil {
++        fmt.Println("error reading from client: ", err.Error())
++        os.Exit(1)
++    }
++
++    if bytes.Contains(buf, []byte("ping")) {
++        conn.Write([]byte("+PONG\r\n"))
++    } else {
++        fmt.Println("received unknown command:", string(buf))
++        os.Exit(1)
++    }
  }


### PR DESCRIPTION
Changes based on https://github.com/codecrafters-io/build-your-own-redis/pull/16#discussion_r933343005. 

- Instead of replying without reading the client's input, we're checking whether the command contains "ping"
- We handle `io.EOF` when reading from a client