### PR TITLE
Fix permissions issue with tests

### DIFF
--- a/compiled_starters/rust/spawn_redis_server.sh
+++ b/compiled_starters/rust/spawn_redis_server.sh
@@ -9,5 +9,5 @@ exec cargo run \
     --quiet \
     --release \
     --target-dir=/tmp/codecrafters-redis-target \
-    --manifest-path $(dirname $0)/Cargo.toml
+    --manifest-path $(dirname $0)/Cargo.toml \
     -- "$@"

--- a/compiled_starters/rust/spawn_redis_server.sh
+++ b/compiled_starters/rust/spawn_redis_server.sh
@@ -9,4 +9,5 @@ exec cargo run \
     --quiet \
     --release \
     --target-dir=/tmp/codecrafters-redis-target \
-    --manifest-path $(dirname $0)/Cargo.toml "$@"
+    --manifest-path $(dirname $0)/Cargo.toml
+    -- "$@"

--- a/solutions/rust/01-init/code/spawn_redis_server.sh
+++ b/solutions/rust/01-init/code/spawn_redis_server.sh
@@ -9,5 +9,5 @@ exec cargo run \
     --quiet \
     --release \
     --target-dir=/tmp/codecrafters-redis-target \
-    --manifest-path $(dirname $0)/Cargo.toml
+    --manifest-path $(dirname $0)/Cargo.toml \
     -- "$@"

--- a/solutions/rust/01-init/code/spawn_redis_server.sh
+++ b/solutions/rust/01-init/code/spawn_redis_server.sh
@@ -9,4 +9,5 @@ exec cargo run \
     --quiet \
     --release \
     --target-dir=/tmp/codecrafters-redis-target \
-    --manifest-path $(dirname $0)/Cargo.toml "$@"
+    --manifest-path $(dirname $0)/Cargo.toml
+    -- "$@"

--- a/starter_templates/rust/spawn_redis_server.sh
+++ b/starter_templates/rust/spawn_redis_server.sh
@@ -9,5 +9,5 @@ exec cargo run \
     --quiet \
     --release \
     --target-dir=/tmp/codecrafters-redis-target \
-    --manifest-path $(dirname $0)/Cargo.toml
+    --manifest-path $(dirname $0)/Cargo.toml \
     -- "$@"

--- a/starter_templates/rust/spawn_redis_server.sh
+++ b/starter_templates/rust/spawn_redis_server.sh
@@ -9,4 +9,5 @@ exec cargo run \
     --quiet \
     --release \
     --target-dir=/tmp/codecrafters-redis-target \
-    --manifest-path $(dirname $0)/Cargo.toml "$@"
+    --manifest-path $(dirname $0)/Cargo.toml
+    -- "$@"


### PR DESCRIPTION
When developing a Rust project, the usual way to run the target binary would be `cargo run`. The current template does that, passing a number of other arguments (silent build, etc.)

There's a problem when trying to go through the extension (RDB access) though. Cargo is able to pass arguments to the target, but it needs to be told where **its own** arguments end. As is, the 

This PR fixes the problem.