### PR TITLE
Update Elixir version to 1.16

### DIFF
--- a/compiled_starters/elixir/codecrafters.yml
+++ b/compiled_starters/elixir/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Elixir version used to run your code
 # on Codecrafters.
 #
-# Available versions: elixir-1.10
-language_pack: elixir-1.10
+# Available versions: elixir-1.16
+language_pack: elixir-1.16

--- a/dockerfiles/elixir-1.16.Dockerfile
+++ b/dockerfiles/elixir-1.16.Dockerfile
@@ -1,0 +1,1 @@
+FROM elixir:1.16-alpine

--- a/solutions/elixir/01-init/code/codecrafters.yml
+++ b/solutions/elixir/01-init/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Elixir version used to run your code
 # on Codecrafters.
 #
-# Available versions: elixir-1.10
-language_pack: elixir-1.10
+# Available versions: elixir-1.16
+language_pack: elixir-1.16

--- a/starter_templates/codecrafters.yml
+++ b/starter_templates/codecrafters.yml
@@ -44,8 +44,8 @@ language_pack: rust-1.70
 language_pack: haskell-9.4
 {{/ language_is_haskell }}
 {{# language_is_elixir}}
-# Available versions: elixir-1.10
-language_pack: elixir-1.10
+# Available versions: elixir-1.16
+language_pack: elixir-1.16
 {{/ language_is_elixir }}
 {{# language_is_kotlin }}
 # Available versions: kotlin-1.4


### PR DESCRIPTION
Elixir 1.10 has a bug where even if args are passed to `mix` after `--`, they get interpreted as args to `mix`. This doesn't seems to be fixed on 1.16. 

Thanks to @robinch for highlighting this!