### PR TITLE
Add -p port to redis-cli calls.

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -609,7 +609,7 @@ stages:
       It'll then send the `INFO` command with `replication` as an argument.
 
       ```bash
-      $ redis-cli info replication
+      $ redis-cli -p <PORT> info replication
       ```
 
       Your program should respond with a [Bulk string](https://redis.io/docs/reference/protocol-spec/#bulk-strings) where each line
@@ -660,7 +660,7 @@ stages:
       It'll then send the `INFO` command with `replication` as an argument to your server.
 
       ```bash
-      $ redis-cli info replication
+      $ redis-cli -p <PORT> info replication
       ```
 
       Your program should respond with a [Bulk string](https://redis.io/docs/reference/protocol-spec/#bulk-strings) where each line


### PR DESCRIPTION
Update course stage descriptions with `-p port` added to `redis-cli` calls.