### PR TITLE
Update course-definition.yml to include old repositories warning

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -556,6 +556,9 @@ stages:
 
       - Your program still needs to pass the previous stages, so if `--port` isn't specified, you should default to port 6379.
       - The tester will pass a random port number to your program, so you can't hardcode the port number from the example above.
+      - If your repository was created before 5th Oct 2023, it's possible that your `./spawn_redis_server.sh` script
+      might not be passing arguments on to your program. You'll need to edit `./spawn_redis_server.sh` to fix this, check
+      [this PR](https://github.com/codecrafters-io/build-your-own-redis/pull/89/files) for details.
     marketing_md: |
       In this stage, you'll add support for parsing the `--port` flag and starting Redis on a custom port.
 


### PR DESCRIPTION
We added this for the RDB extension, but not for the replication one. Thanks to @scjuly19 for highlighting this!