### PR TITLE
Fix missing args parse for zig

### DIFF
--- a/compiled_starters/zig/build.zig
+++ b/compiled_starters/zig/build.zig
@@ -24,4 +24,10 @@ pub fn build(b: *std.Build) void {
     // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 }

--- a/solutions/zig/01-jm1/code/build.zig
+++ b/solutions/zig/01-jm1/code/build.zig
@@ -24,4 +24,10 @@ pub fn build(b: *std.Build) void {
     // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 }

--- a/starter_templates/zig/build.zig
+++ b/starter_templates/zig/build.zig
@@ -24,4 +24,10 @@ pub fn build(b: *std.Build) void {
     // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 }


### PR DESCRIPTION
There was a missing step in `build.zig` that was required for the ability to parse args when running the program using
```sh
zig build run -- $args
```