### PR TITLE
fix course description for stream extension

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -2644,7 +2644,7 @@ stages:
       ```text
       *1\r\n
       *2\r\n
-      $9\r\nstream_key\r\n
+      $10\r\nstream_key\r\n
       *1\r\n
       *2\r\n
       $3\r\n0-1\r\n

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -2864,7 +2864,7 @@ stages:
       ```text
       *1\r\n
       *2\r\n
-      $9\r\stream_key\r\n
+      $10\r\stream_key\r\n
       *1\r\n
       *2\r\n
       $3\r\n0-2\r\n
@@ -2989,7 +2989,7 @@ stages:
       ```text
       *1\r\n
       *2\r\n
-      $9\r\stream_key\r\n
+      $10\r\stream_key\r\n
       *1\r\n
       *2\r\n
       $3\r\n0-2\r\n
@@ -3117,7 +3117,7 @@ stages:
       ```text
       *1\r\n
       *2\r\n
-      $9\r\stream_key\r\n
+      $10\r\stream_key\r\n
       *1\r\n
       *2\r\n
       $3\r\n0-2\r\n


### PR DESCRIPTION
This PR fixes an error in the course description for Redis Streams extension
Length of `stream_key` is 10, not 9, so it's representation in RESP should be `$10\r\nstream_key\r\n`
