### PR TITLE
Fix CC-1354: Go toolchain issue 

### DIFF
--- a/compiled_starters/go/go.mod
+++ b/compiled_starters/go/go.mod
@@ -8,4 +8,4 @@
 
 module github.com/codecrafters-io/redis-starter-go
 
-go 1.22
+go 1.22.0

--- a/solutions/go/01-jm1/code/go.mod
+++ b/solutions/go/01-jm1/code/go.mod
@@ -8,4 +8,4 @@
 
 module github.com/codecrafters-io/redis-starter-go
 
-go 1.22
+go 1.22.0

--- a/starter_templates/go/code/go.mod
+++ b/starter_templates/go/code/go.mod
@@ -8,4 +8,4 @@
 
 module github.com/codecrafters-io/redis-starter-go
 
-go 1.22
+go 1.22.0


### PR DESCRIPTION
TLDR:

> go 1.21 was a `development version` of the language, for which there is no downloadable release (because it is not a specific version). The `release version` would be go 1.21.0

https://github.com/golang/go/issues/62278#issuecomment-1693538776 