### PR TITLE
Bump RDB version to 11 in instructions for stage "Read a key" #jz6

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -570,10 +570,10 @@ stages:
 
       RDB files begin with a header section, which looks something like this:
       ```
-      52 45 44 49 53 30 30 30 37  // Magic string + version number (ASCII): "REDIS0007".
+      52 45 44 49 53 30 30 31 31  // Magic string + version number (ASCII): "REDIS0011".
       ```
 
-      The header contains the magic string `REDIS`, followed by a four-character RDB version number. In this challenge, the test RDB files all use version 7. So, the header is always `REDIS0007`.
+      The header contains the magic string `REDIS`, followed by a four-character RDB version number. In this challenge, the test RDB files all use version 11. So, the header is always `REDIS0011`.
 
       #### Metadata section
 


### PR DESCRIPTION
Thanks @AlRodriguezGar14 for highlighting the discrepancy!

Reason: [Forum #1615](https://forum.codecrafters.io/t/handle-rdb-version-differences/1615)

Discussion with Ryan: [(TLDR) We have an outdated external library `rdb` that can be upgraded.](https://codecrafters-io.slack.com/archives/C07H9EY1Z6X/p1725341804370929)

In tandem with https://github.com/codecrafters-io/redis-tester/pull/164