### PR TITLE
Add support for Swift

### DIFF
--- a/compiled_starters/swift/.codecrafters/compile.sh
+++ b/compiled_starters/swift/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/compiled_starters/swift/.codecrafters/run.sh
+++ b/compiled_starters/swift/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec swift run -c release --skip-build --build-path /tmp/codecrafters-build-redis-swift build-your-own-redis "$@"

--- a/compiled_starters/swift/.gitattributes
+++ b/compiled_starters/swift/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/compiled_starters/swift/.gitignore
+++ b/compiled_starters/swift/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+.build
+Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/compiled_starters/swift/Package.resolved
+++ b/compiled_starters/swift/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "c36d8cad89fe8f5758a63a0c19924ef816667b8179783721c583fc3b73e5aff7",
+  "pins" : [
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "1b33db2dea6a64d5b619b9e888175133c6d7f410",
+        "version" : "2.73.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
+        "version" : "1.3.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/compiled_starters/swift/Package.swift
+++ b/compiled_starters/swift/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "build-your-own-redis",
+     dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.73.0")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "build-your-own-redis",
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio")
+            ]
+        ),
+    ]
+)

--- a/compiled_starters/swift/README.md
+++ b/compiled_starters/swift/README.md
@@ -1,0 +1,33 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for Swift solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in `Sources/main.swift`. Study
+and uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `swift (>=6.0)` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `Sources/main.swift`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/compiled_starters/swift/Sources/main.swift
+++ b/compiled_starters/swift/Sources/main.swift
@@ -1,0 +1,30 @@
+import Foundation
+import NIO
+
+// You can use print statements as follows for debugging, they'll be visible when running tests.
+print("Logs from your program will appear here!")
+
+// Create an event loop group to manage network events
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
+// Shut down the event loop group
+defer {
+    try? group.syncShutdownGracefully()
+}
+
+// Set up a channel for the server to listen on port 6379
+let serverBootstrap = ServerBootstrap(group: group)
+// Set SO_REUSEADDR to true
+    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+// Handle incoming connections
+    .childChannelInitializer { channel in
+        // You can add channel handlers here if needed
+        return channel.eventLoop.makeSucceededFuture(())
+    }
+
+// Uncomment this block to pass the first stage
+//// Bind the server to port 6379 and start accepting connections
+//let channel = try serverBootstrap.bind(host: "localhost", port: 6379).wait()
+//print("Server started and listening on \(channel.localAddress!)")
+//try channel.closeFuture.wait()
+//print("Server closed")

--- a/compiled_starters/swift/codecrafters.yml
+++ b/compiled_starters/swift/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Swift version used to run your code
+# on Codecrafters.
+#
+# Available versions: swift-6.0
+language_pack: swift-6.0

--- a/compiled_starters/swift/your_program.sh
+++ b/compiled_starters/swift/your_program.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec swift run -c release --skip-build --build-path /tmp/codecrafters-build-redis-swift build-your-own-redis "$@"

--- a/dockerfiles/swift-6.0.Dockerfile
+++ b/dockerfiles/swift-6.0.Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 # .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
 COPY --exclude=.git --exclude=README.md . /app
 
-# Cache dependencies
+RUN .codecrafters/compile.sh
+
+# Cache dependencies (TODO: Check if this is required, or whether build implicitly caches dependencies)
 RUN swift package --build-path /tmp/codecrafters-build-redis-swift resolve
-RUN swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/dockerfiles/swift-6.0.Dockerfile
+++ b/dockerfiles/swift-6.0.Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM swift:6.0-focal
+
+# Ensures the container is re-built if Package.swift changes
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Package.swift"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Cache dependencies
+RUN swift package --build-path /tmp/codecrafters-build-redis-swift resolve
+RUN swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/solutions/swift/01-jm1/code/.codecrafters/compile.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/solutions/swift/01-jm1/code/.codecrafters/run.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec swift run -c release --skip-build --build-path /tmp/codecrafters-build-redis-swift build-your-own-redis "$@"

--- a/solutions/swift/01-jm1/code/.gitattributes
+++ b/solutions/swift/01-jm1/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/swift/01-jm1/code/.gitignore
+++ b/solutions/swift/01-jm1/code/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+.build
+Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/solutions/swift/01-jm1/code/Package.resolved
+++ b/solutions/swift/01-jm1/code/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "c36d8cad89fe8f5758a63a0c19924ef816667b8179783721c583fc3b73e5aff7",
+  "pins" : [
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "1b33db2dea6a64d5b619b9e888175133c6d7f410",
+        "version" : "2.73.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
+        "version" : "1.3.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/solutions/swift/01-jm1/code/Package.swift
+++ b/solutions/swift/01-jm1/code/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "build-your-own-redis",
+     dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.73.0")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "build-your-own-redis",
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio")
+            ]
+        ),
+    ]
+)

--- a/solutions/swift/01-jm1/code/README.md
+++ b/solutions/swift/01-jm1/code/README.md
@@ -1,0 +1,33 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for Swift solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in `Sources/main.swift`. Study
+and uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `swift (>=6.0)` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `Sources/main.swift`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/swift/01-jm1/code/Sources/main.swift
+++ b/solutions/swift/01-jm1/code/Sources/main.swift
@@ -1,0 +1,26 @@
+import Foundation
+import NIO
+
+// Create an event loop group to manage network events
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
+// Shut down the event loop group
+defer {
+    try? group.syncShutdownGracefully()
+}
+
+// Set up a channel for the server to listen on port 6379
+let serverBootstrap = ServerBootstrap(group: group)
+// Set SO_REUSEADDR to true
+    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+// Handle incoming connections
+    .childChannelInitializer { channel in
+        // You can add channel handlers here if needed
+        return channel.eventLoop.makeSucceededFuture(())
+    }
+
+// Bind the server to port 6379 and start accepting connections
+let channel = try serverBootstrap.bind(host: "localhost", port: 6379).wait()
+print("Server started and listening on \(channel.localAddress!)")
+try channel.closeFuture.wait()
+print("Server closed")

--- a/solutions/swift/01-jm1/code/codecrafters.yml
+++ b/solutions/swift/01-jm1/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Swift version used to run your code
+# on Codecrafters.
+#
+# Available versions: swift-6.0
+language_pack: swift-6.0

--- a/solutions/swift/01-jm1/code/your_program.sh
+++ b/solutions/swift/01-jm1/code/your_program.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec swift run -c release --skip-build --build-path /tmp/codecrafters-build-redis-swift build-your-own-redis "$@"

--- a/solutions/swift/01-jm1/diff/Sources/main.swift.diff
+++ b/solutions/swift/01-jm1/diff/Sources/main.swift.diff
@@ -1,0 +1,36 @@
+@@ -1,30 +1,26 @@
+ import Foundation
+ import NIO
+
+-// You can use print statements as follows for debugging, they'll be visible when running tests.
+-print("Logs from your program will appear here!")
+-
+ // Create an event loop group to manage network events
+ let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
+ // Shut down the event loop group
+ defer {
+     try? group.syncShutdownGracefully()
+ }
+
+ // Set up a channel for the server to listen on port 6379
+ let serverBootstrap = ServerBootstrap(group: group)
+ // Set SO_REUSEADDR to true
+     .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+ // Handle incoming connections
+     .childChannelInitializer { channel in
+         // You can add channel handlers here if needed
+         return channel.eventLoop.makeSucceededFuture(())
+     }
+
+-// Uncomment this block to pass the first stage
+-//// Bind the server to port 6379 and start accepting connections
+-//let channel = try serverBootstrap.bind(host: "localhost", port: 6379).wait()
+-//print("Server started and listening on \(channel.localAddress!)")
+-//try channel.closeFuture.wait()
+-//print("Server closed")
++// Bind the server to port 6379 and start accepting connections
++let channel = try serverBootstrap.bind(host: "localhost", port: 6379).wait()
++print("Server started and listening on \(channel.localAddress!)")
++try channel.closeFuture.wait()
++print("Server closed")

--- a/solutions/swift/01-jm1/explanation.md
+++ b/solutions/swift/01-jm1/explanation.md
@@ -1,0 +1,20 @@
+The entry point for your Redis implementation is in `Sources/main.swift`.
+
+Study and uncomment the relevant code: 
+
+```swift
+// Uncomment this block to pass the first stage
+// Bind the server to port 6379 and start accepting connections
+let channel = try serverBootstrap.bind(host: "localhost", port: 6379).wait()
+print("Server started and listening on \(channel.localAddress!)")
+try channel.closeFuture.wait()
+print("Server closed")
+```
+
+Push your changes to pass the first stage:
+
+```
+git add .
+git commit -m "pass 1st stage" # any msg
+git push origin master
+```

--- a/starter_templates/swift/code/.codecrafters/compile.sh
+++ b/starter_templates/swift/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/starter_templates/swift/code/.codecrafters/run.sh
+++ b/starter_templates/swift/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec swift run -c release --skip-build --build-path /tmp/codecrafters-build-redis-swift build-your-own-redis "$@"

--- a/starter_templates/swift/code/.gitignore
+++ b/starter_templates/swift/code/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+.build
+Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/starter_templates/swift/code/Package.resolved
+++ b/starter_templates/swift/code/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "c36d8cad89fe8f5758a63a0c19924ef816667b8179783721c583fc3b73e5aff7",
+  "pins" : [
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "1b33db2dea6a64d5b619b9e888175133c6d7f410",
+        "version" : "2.73.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "d2ba781702a1d8285419c15ee62fd734a9437ff5",
+        "version" : "1.3.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/starter_templates/swift/code/Package.swift
+++ b/starter_templates/swift/code/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "build-your-own-redis",
+     dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.73.0")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "build-your-own-redis",
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio")
+            ]
+        ),
+    ]
+)

--- a/starter_templates/swift/code/Sources/main.swift
+++ b/starter_templates/swift/code/Sources/main.swift
@@ -1,0 +1,30 @@
+import Foundation
+import NIO
+
+// You can use print statements as follows for debugging, they'll be visible when running tests.
+print("Logs from your program will appear here!")
+
+// Create an event loop group to manage network events
+let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
+// Shut down the event loop group
+defer {
+    try? group.syncShutdownGracefully()
+}
+
+// Set up a channel for the server to listen on port 6379
+let serverBootstrap = ServerBootstrap(group: group)
+// Set SO_REUSEADDR to true
+    .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+// Handle incoming connections
+    .childChannelInitializer { channel in
+        // You can add channel handlers here if needed
+        return channel.eventLoop.makeSucceededFuture(())
+    }
+
+// Uncomment this block to pass the first stage
+//// Bind the server to port 6379 and start accepting connections
+//let channel = try serverBootstrap.bind(host: "localhost", port: 6379).wait()
+//print("Server started and listening on \(channel.localAddress!)")
+//try channel.closeFuture.wait()
+//print("Server closed")

--- a/starter_templates/swift/config.yml
+++ b/starter_templates/swift/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: "swift (>=6.0)"
+  user_editable_file: Sources/main.swift


### PR DESCRIPTION
This PR adds Swift as a viable option using the changes I added to the [language templates repo PR](https://github.com/codecrafters-io/language-templates/pull/2).

I tested locally by pointing course-sdk to my repo which included the new language.

I'm not an expert in swift-nio, but the provided script code succeeded when running `course-sdk test swift`. With the recent changes I made to the language templates PR linked above, swift-nio gets built when the image is built and is available to use as a cache for the incremental build required to run the program. It took a total of 12 seconds to run the starter and solution scripts combined which you can see in the screenshot below.

![CleanShot 2024-09-29 at 22 29 48@2x](https://github.com/user-attachments/assets/64bfb772-3db7-4a64-b376-ead912db95bf)


