### PR TITLE
[Redis] [CC-1642] Upgrade Gleam to 1.9

### DIFF
--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `gleam (1.0+)` installed locally
+1. Ensure you have `gleam (1.9.1)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.gleam`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/gleam/codecrafters.yml
+++ b/compiled_starters/gleam/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.6
-language_pack: gleam-1.6
+# Available versions: gleam-1.9
+language_pack: gleam-1.9

--- a/dockerfiles/gleam-1.9.Dockerfile
+++ b/dockerfiles/gleam-1.9.Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ghcr.io/gleam-lang/gleam:v1.9.1-erlang-alpine
+
+# Rebuild if gleam.toml or manifest.toml change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="gleam.toml,manifest.toml"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Force deps to be downloaded
+RUN gleam build
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv build /app-cached/build

--- a/solutions/gleam/01-jm1/code/README.md
+++ b/solutions/gleam/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `gleam (1.0+)` installed locally
+1. Ensure you have `gleam (1.9.1)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.gleam`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/gleam/01-jm1/code/codecrafters.yml
+++ b/solutions/gleam/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.6
-language_pack: gleam-1.6
+# Available versions: gleam-1.9
+language_pack: gleam-1.9

--- a/starter_templates/gleam/config.yml
+++ b/starter_templates/gleam/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: gleam (1.0+)
+  required_executable: gleam (1.9.1)
   user_editable_file: src/main.gleam


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new containerized build setup supporting Gleam 1.9.1.

- **Documentation**
  - Updated the installation instructions to require Gleam 1.9.1 for local development.

- **Chores**
  - Upgraded configuration settings and language pack references from earlier Gleam versions to 1.9, ensuring consistency across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->