### PR TITLE
[Redis] CC-1656 Upgrade Zig to 0.14

### DIFF
--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.13+)` installed locally
+1. Ensure you have `zig (0.14)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/zig/build.zig.zon
+++ b/compiled_starters/zig/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "codecrafters-redis",
+    .name = .codecrafters_redis,
+    .fingerprint = 0xf806bb97907ce4a5,
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
@@ -8,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/compiled_starters/zig/codecrafters.yml
+++ b/compiled_starters/zig/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.13
-language_pack: zig-0.13
+# Available versions: zig-0.14
+language_pack: zig-0.14

--- a/dockerfiles/zig-0.14.Dockerfile
+++ b/dockerfiles/zig-0.14.Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM alpine:3.20
+
+RUN apk add --no-cache 'xz>=5.6' 'curl>=8.9'
+
+# Download and install Zig
+RUN curl -O https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz \
+    && tar -xf zig-linux-x86_64-0.14.0.tar.xz \
+    && mv zig-linux-x86_64-0.14.0 /usr/local/zig \
+    && rm zig-linux-x86_64-0.14.0.tar.xz
+
+# Add Zig to PATH
+ENV PATH="/usr/local/zig:${PATH}"
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="build.zig,build.zig.zon"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs zig build
+RUN .codecrafters/compile.sh
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv /app/.zig-cache /app-cached/.zig-cache || true

--- a/solutions/zig/01-jm1/code/README.md
+++ b/solutions/zig/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.13+)` installed locally
+1. Ensure you have `zig (0.14)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/zig/01-jm1/code/build.zig.zon
+++ b/solutions/zig/01-jm1/code/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "codecrafters-redis",
+    .name = .codecrafters_redis,
+    .fingerprint = 0xf806bb97907ce4a5,
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
@@ -8,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/solutions/zig/01-jm1/code/codecrafters.yml
+++ b/solutions/zig/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.13
-language_pack: zig-0.13
+# Available versions: zig-0.14
+language_pack: zig-0.14

--- a/starter_templates/zig/code/build.zig.zon
+++ b/starter_templates/zig/code/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "codecrafters-redis",
+    .name = .codecrafters_redis,
+    .fingerprint = 0xf806bb97907ce4a5,
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
@@ -8,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.14.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/starter_templates/zig/config.yml
+++ b/starter_templates/zig/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: zig (0.13+)
+  required_executable: zig (0.14)
   user_editable_file: src/main.zig


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions now require Zig version 0.14 instead of the previous release, ensuring alignment with the latest environment.

- **Chores**
  - Revised package configurations to improve consistency and unique package identification.

- **New Features**
  - Introduced a new container setup that streamlines dependency management for Zig version 0.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->