### PR TITLE
[Redis] CC-1646: Upgrade Python support to 3.13

### DIFF
--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `python (3.x)` installed locally
+1. Ensure you have `python (3.13)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.py`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/python/codecrafters.yml
+++ b/compiled_starters/python/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Python version used to run your code
 # on Codecrafters.
 #
-# Available versions: python-3.12
-language_pack: python-3.12
+# Available versions: python-3.13
+language_pack: python-3.13

--- a/dockerfiles/python-3.13.Dockerfile
+++ b/dockerfiles/python-3.13.Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.13-alpine

--- a/solutions/python/01-jm1/code/README.md
+++ b/solutions/python/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `python (3.x)` installed locally
+1. Ensure you have `python (3.13)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.py`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/python/01-jm1/code/codecrafters.yml
+++ b/solutions/python/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Python version used to run your code
 # on Codecrafters.
 #
-# Available versions: python-3.12
-language_pack: python-3.12
+# Available versions: python-3.13
+language_pack: python-3.13

--- a/solutions/python/02-rg2/code/codecrafters.yml
+++ b/solutions/python/02-rg2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Python version used to run your code
 # on Codecrafters.
 #
-# Available versions: python-3.12
-language_pack: python-3.12
+# Available versions: python-3.13
+language_pack: python-3.13

--- a/solutions/python/02-rg2/diff/README.md.diff
+++ b/solutions/python/02-rg2/diff/README.md.diff
@@ -1,0 +1,53 @@
+@@ -4,51 +4,51 @@
+ ["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+ In this challenge, you'll build a toy Redis clone that's capable of handling
+ basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+ event loops, the Redis protocol and more.
+
+ **Note**: If you're viewing this repo on GitHub, head over to
+ [codecrafters.io](https://codecrafters.io) to try the challenge.
+
+ # Passing the first stage
+
+ The entry point for your Redis implementation is in `app/main.py`. Study and
+ uncomment the relevant code, and push your changes to pass the first stage:
+
+ ```sh
+ git commit -am "pass 1st stage" # any msg
+ git push origin master
+ ```
+
+ That's all!
+
+ # Stage 2 & beyond
+
+ Note: This section is for stages 2 and beyond.
+
+-1. Ensure you have `python (3.13)` installed locally
++1. Ensure you have `python (3.x)` installed locally
+ 1. Run `./your_program.sh` to run your Redis server, which is implemented in
+    `app/main.py`.
+ 1. Commit your changes and run `git push origin master` to submit your solution
+    to CodeCrafters. Test output will be streamed to your terminal.
+
+ # Troubleshooting
+
+ ## module `socket` has no attribute `create_server`
+
+ When running your server locally, you might see an error like this:
+
+ ```
+ Traceback (most recent call last):
+   File "/.../python3.7/runpy.py", line 193, in _run_module_as_main
+     "__main__", mod_spec)
+   File "/.../python3.7/runpy.py", line 85, in _run_code
+     exec(code, run_globals)
+   File "/app/app/main.py", line 11, in <module>
+     main()
+   File "/app/app/main.py", line 6, in main
+     s = socket.create_server(("localhost", 6379), reuse_port=True)
+ AttributeError: module 'socket' has no attribute 'create_server'
+ ```
+
+ This is because `socket.create_server` was introduced in Python 3.8, and you

--- a/starter_templates/python/config.yml
+++ b/starter_templates/python/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: python (3.x)
+  required_executable: python (3.13)
   user_editable_file: app/main.py


### PR DESCRIPTION
Upgrade the Python version in configuration and documentation files to 3.13. Introduce a Dockerfile for setting up a Python 3.13 environment with Pipenv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Installation guides and challenge instructions now clearly specify Python version 3.13 for improved consistency.
  
- **New Features**
  - Introduced a lightweight Docker environment using Python 3.13 to enhance deployment efficiency.
  
- **Chores**
  - Updated configuration settings across the project to align with the new Python version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->