### PR TITLE
Make it even clearer that the empty RDB file needs to be in binary

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -1376,7 +1376,7 @@ stages:
       The file is sent using the following format:
 
       ```
-      $<length_of_file>\r\n<contents_of_file>
+      $<length_of_file>\r\n<binary_contents_of_file>
       ```
 
       (This is similar to how [Bulk Strings](https://redis.io/topics/protocol#resp-bulk-strings) are encoded, but without the trailing `\r\n`)
@@ -1404,7 +1404,7 @@ stages:
         of the file. You need to decode these into binary contents before sending it to the replica.
       - The RDB file should be sent like this: `$<length>\r\n<contents>`
         - `<length>` is the length of the file in bytes
-        - `<contents>` is the contents of the file
+        - `<contents>` is the binary contents of the file
         - Note that this is NOT a RESP bulk string, it doesn't contain a `\r\n` at the end
       - If you want to learn more about the RDB file format, read [this blog post](https://rdb.fnordig.de/file_format.html). This challenge
         has a separate extension dedicated to reading RDB files.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that RDB file contents must be sent as binary data during replication full resynchronization.
  - Updated example formats and explanatory notes to emphasize binary transmission requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->