### PR TITLE
CC-1731: Fix Redis #bs1 and #xu1

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -2893,17 +2893,19 @@ stages:
         [
           "stream_key",
           [
-            "0-2",
             [
-              "temperature",
-              "96"
+              "0-2",
+              [
+                "temperature",
+                "96"
+              ]
             ]
           ]
         ]
       ]
       ```
 
-      It'll send another `XREAD` command to your server with the `BLOCK` command but this time, it'll wait for 2000 milliseconds before checking the response of your server.
+      It'll send another `XREAD` command to your server with the `BLOCK` command but this time, it'll wait for 1000 milliseconds before checking the response of your server.
 
       ```bash
       $ redis-cli XREAD block 1000 streams stream_key 0-2
@@ -3018,10 +3020,12 @@ stages:
         [
           "stream_key",
           [
-            "0-2",
             [
-              "temperature",
-              "95"
+              "0-2",
+              [
+                "temperature",
+                "95"
+              ]
             ]
           ]
         ]
@@ -3146,17 +3150,19 @@ stages:
         [
           "stream_key",
           [
-            "0-2",
             [
-              "temperature",
-              "95"
+              "0-2",
+              [
+                "temperature",
+                "95"
+              ]
             ]
           ]
         ]
       ]
       ```
 
-      It'll send another `XREAD` command to your server with the `BLOCK` command but this time, it'll wait for 2000 milliseconds before checking the response of your server.
+      It'll send another `XREAD` command to your server with the `BLOCK` command but this time, it'll wait for 1000 milliseconds before checking the response of your server.
 
       ```bash
       $ redis-cli XREAD block 1000 streams stream_key $


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the expected response structure for stream entries in the "Blocking reads" stages to match the updated format.
  - Updated blocking timeout durations in descriptive text and examples from 2000ms to 1000ms for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->