### PR TITLE
[Redis] CC-1745: Upgrade Bun to v1.2, Rust to v1.86, and Elixir to v1.18

### DIFF
--- a/compiled_starters/elixir/.codecrafters/compile.sh
+++ b/compiled_starters/elixir/.codecrafters/compile.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-# (This file is empty since Elixir programs don't use a compile step)
+mix escript.build
+mv codecrafters_redis /tmp/codecrafters-build-redis-elixir

--- a/compiled_starters/elixir/.codecrafters/run.sh
+++ b/compiled_starters/elixir/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec mix run --no-halt -- "$@"
+exec /tmp/codecrafters-build-redis-elixir "$@"

--- a/compiled_starters/elixir/.gitignore
+++ b/compiled_starters/elixir/.gitignore
@@ -1,3 +1,6 @@
+# Ignore the compiled binary
+/codecrafters_redis
+
 # The directory Mix will write compiled artifacts to.
 /_build/
 

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -12,7 +12,7 @@ event loops, the Redis protocol and more.
 
 # Passing the first stage
 
-The entry point for your Redis implementation is in `lib/server.ex`. Study and
+The entry point for your Redis implementation is in `lib/main.ex`. Study and
 uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
@@ -28,6 +28,6 @@ Note: This section is for stages 2 and beyond.
 
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
-   `lib/server.ex`.
+   `lib/main.ex`.
 1. Commit your changes and run `git push origin master` to submit your solution
    to CodeCrafters. Test output will be streamed to your terminal.

--- a/compiled_starters/elixir/codecrafters.yml
+++ b/compiled_starters/elixir/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Elixir version used to run your code
 # on Codecrafters.
 #
-# Available versions: elixir-1.16
-language_pack: elixir-1.16
+# Available versions: elixir-1.18
+language_pack: elixir-1.18

--- a/compiled_starters/elixir/lib/main.ex
+++ b/compiled_starters/elixir/lib/main.ex
@@ -2,7 +2,7 @@ defmodule Server do
   @moduledoc """
   Your implementation of a Redis server
   """
-
+  
   use Application
 
   def start(_type, _args) do
@@ -22,5 +22,15 @@ defmodule Server do
     # # ensures that we don't run into 'Address already in use' errors
     # {:ok, socket} = :gen_tcp.listen(6379, [:binary, active: false, reuseaddr: true])
     # {:ok, _client} = :gen_tcp.accept(socket)
+  end
+end
+
+defmodule CLI do
+  def main(_args) do
+    # Start the Server application
+    {:ok, _pid} = Application.ensure_all_started(:codecrafters_redis)
+
+    # Run forever
+    Process.sleep(:infinity)
   end
 end

--- a/compiled_starters/elixir/mix.exs
+++ b/compiled_starters/elixir/mix.exs
@@ -4,17 +4,28 @@ defmodule App.MixProject do
 
   def project do
     [
-      app: :redis,
+      app: :codecrafters_redis,
       version: "1.0.0",
-      elixir: "~> 1.10",
-      start_permanent: Mix.env() == :prod
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      escript: [main_module: CLI]
     ]
   end
 
+  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger],
       mod: {Server, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]
   end
 end

--- a/compiled_starters/elixir/your_program.sh
+++ b/compiled_starters/elixir/your_program.sh
@@ -8,8 +8,18 @@
 
 set -e # Exit early if any commands fail
 
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  mix escript.build
+  mv codecrafters_redis /tmp/codecrafters-build-redis-elixir
+)
+
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec mix run --no-halt -- "$@"
+exec /tmp/codecrafters-build-redis-elixir "$@"

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.82)` installed locally
+1. Ensure you have `cargo (1.86)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.85
-language_pack: rust-1.85
+# Available versions: rust-1.86
+language_pack: rust-1.86

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `bun (1.1)` installed locally
+1. Ensure you have `bun (1.2)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.ts`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/typescript/codecrafters.yml
+++ b/compiled_starters/typescript/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the TypeScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: bun-1.1
-language_pack: bun-1.1
+# Available versions: bun-1.2
+language_pack: bun-1.2

--- a/dockerfiles/bun-1.2.Dockerfile
+++ b/dockerfiles/bun-1.2.Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM oven/bun:1.2-alpine
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="package.json,bun.lockb"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# For reproducible builds.
+# This will install the exact versions of each package specified in the lockfile.
+# If package.json disagrees with bun.lockb, Bun will exit with an error. The lockfile will not be updated.
+RUN bun install --frozen-lockfile
+
+# If the node_modules directory exists, move it to /app-cached
+RUN mkdir -p /app-cached
+RUN if [ -d "/app/node_modules" ]; then mv /app/node_modules /app-cached; fi

--- a/dockerfiles/elixir-1.18.Dockerfile
+++ b/dockerfiles/elixir-1.18.Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM elixir:1.18.3-alpine
+
+# Ensures the container is re-built if dependency files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="mix.exs"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# install hex + rebar
+RUN mix local.hex --force && \
+  mix local.rebar --force
+
+# install and compile mix dependencies
+RUN mix deps.get && \
+  mix deps.compile
+
+# Install & cache deps
+RUN .codecrafters/compile.sh
+
+RUN mkdir -p /app-cached
+RUN if [ -d "/app/_build" ]; then mv /app/_build /app-cached; fi
+RUN if [ -d "/app/deps" ]; then mv /app/deps /app-cached; fi

--- a/dockerfiles/rust-1.86.Dockerfile
+++ b/dockerfiles/rust-1.86.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.86-bookworm
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/elixir/01-jm1/code/.codecrafters/compile.sh
+++ b/solutions/elixir/01-jm1/code/.codecrafters/compile.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-# (This file is empty since Elixir programs don't use a compile step)
+mix escript.build
+mv codecrafters_redis /tmp/codecrafters-build-redis-elixir

--- a/solutions/elixir/01-jm1/code/.codecrafters/run.sh
+++ b/solutions/elixir/01-jm1/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec mix run --no-halt -- "$@"
+exec /tmp/codecrafters-build-redis-elixir "$@"

--- a/solutions/elixir/01-jm1/code/.gitignore
+++ b/solutions/elixir/01-jm1/code/.gitignore
@@ -1,3 +1,6 @@
+# Ignore the compiled binary
+/codecrafters_redis
+
 # The directory Mix will write compiled artifacts to.
 /_build/
 

--- a/solutions/elixir/01-jm1/code/README.md
+++ b/solutions/elixir/01-jm1/code/README.md
@@ -12,7 +12,7 @@ event loops, the Redis protocol and more.
 
 # Passing the first stage
 
-The entry point for your Redis implementation is in `lib/server.ex`. Study and
+The entry point for your Redis implementation is in `lib/main.ex`. Study and
 uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
@@ -28,6 +28,6 @@ Note: This section is for stages 2 and beyond.
 
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
-   `lib/server.ex`.
+   `lib/main.ex`.
 1. Commit your changes and run `git push origin master` to submit your solution
    to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/elixir/01-jm1/code/codecrafters.yml
+++ b/solutions/elixir/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Elixir version used to run your code
 # on Codecrafters.
 #
-# Available versions: elixir-1.16
-language_pack: elixir-1.16
+# Available versions: elixir-1.18
+language_pack: elixir-1.18

--- a/solutions/elixir/01-jm1/code/lib/main.ex
+++ b/solutions/elixir/01-jm1/code/lib/main.ex
@@ -2,7 +2,7 @@ defmodule Server do
   @moduledoc """
   Your implementation of a Redis server
   """
-
+  
   use Application
 
   def start(_type, _args) do
@@ -17,5 +17,15 @@ defmodule Server do
     # ensures that we don't run into 'Address already in use' errors
     {:ok, socket} = :gen_tcp.listen(6379, [:binary, active: false, reuseaddr: true])
     {:ok, _client} = :gen_tcp.accept(socket)
+  end
+end
+
+defmodule CLI do
+  def main(_args) do
+    # Start the Server application
+    {:ok, _pid} = Application.ensure_all_started(:codecrafters_redis)
+
+    # Run forever
+    Process.sleep(:infinity)
   end
 end

--- a/solutions/elixir/01-jm1/code/mix.exs
+++ b/solutions/elixir/01-jm1/code/mix.exs
@@ -4,17 +4,28 @@ defmodule App.MixProject do
 
   def project do
     [
-      app: :redis,
+      app: :codecrafters_redis,
       version: "1.0.0",
-      elixir: "~> 1.10",
-      start_permanent: Mix.env() == :prod
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      escript: [main_module: CLI]
     ]
   end
 
+  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger],
       mod: {Server, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]
   end
 end

--- a/solutions/elixir/01-jm1/code/your_program.sh
+++ b/solutions/elixir/01-jm1/code/your_program.sh
@@ -8,8 +8,18 @@
 
 set -e # Exit early if any commands fail
 
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  mix escript.build
+  mv codecrafters_redis /tmp/codecrafters-build-redis-elixir
+)
+
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec mix run --no-halt -- "$@"
+exec /tmp/codecrafters-build-redis-elixir "$@"

--- a/solutions/elixir/01-jm1/diff/lib/main.ex.diff
+++ b/solutions/elixir/01-jm1/diff/lib/main.ex.diff
@@ -1,9 +1,9 @@
-@@ -1,26 +1,21 @@
+@@ -1,36 +1,31 @@
  defmodule Server do
    @moduledoc """
    Your implementation of a Redis server
    """
-
+   
    use Application
 
    def start(_type, _args) do
@@ -29,3 +29,14 @@
 +    {:ok, _client} = :gen_tcp.accept(socket)
    end
  end
+
+ defmodule CLI do
+   def main(_args) do
+     # Start the Server application
+     {:ok, _pid} = Application.ensure_all_started(:codecrafters_redis)
+
+     # Run forever
+     Process.sleep(:infinity)
+   end
+ end
+\ No newline at end of file

--- a/solutions/elixir/01-jm1/explanation.md
+++ b/solutions/elixir/01-jm1/explanation.md
@@ -1,4 +1,4 @@
-The entry point for your Redis implementation is in `lib/server.ex`.
+The entry point for your Redis implementation is in `lib/main.ex`.
 
 Study and uncomment the relevant code: 
 

--- a/solutions/rust/01-jm1/code/README.md
+++ b/solutions/rust/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.82)` installed locally
+1. Ensure you have `cargo (1.86)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-jm1/code/codecrafters.yml
+++ b/solutions/rust/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.85
-language_pack: rust-1.85
+# Available versions: rust-1.86
+language_pack: rust-1.86

--- a/solutions/rust/02-rg2/code/codecrafters.yml
+++ b/solutions/rust/02-rg2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.85
-language_pack: rust-1.85
+# Available versions: rust-1.86
+language_pack: rust-1.86

--- a/solutions/rust/02-rg2/diff/README.md.diff
+++ b/solutions/rust/02-rg2/diff/README.md.diff
@@ -1,0 +1,33 @@
+@@ -4,31 +4,31 @@
+ ["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+ In this challenge, you'll build a toy Redis clone that's capable of handling
+ basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+ event loops, the Redis protocol and more.
+
+ **Note**: If you're viewing this repo on GitHub, head over to
+ [codecrafters.io](https://codecrafters.io) to try the challenge.
+
+ # Passing the first stage
+
+ The entry point for your Redis implementation is in `src/main.rs`. Study and
+ uncomment the relevant code, and push your changes to pass the first stage:
+
+ ```sh
+ git commit -am "pass 1st stage" # any msg
+ git push origin master
+ ```
+
+ That's all!
+
+ # Stage 2 & beyond
+
+ Note: This section is for stages 2 and beyond.
+
+-1. Ensure you have `cargo (1.86)` installed locally
++1. Ensure you have `cargo (1.82)` installed locally
+ 1. Run `./your_program.sh` to run your Redis server, which is implemented in
+    `src/main.rs`. This command compiles your Rust project, so it might be slow
+    the first time you run it. Subsequent runs will be fast.
+ 1. Commit your changes and run `git push origin master` to submit your solution
+    to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/typescript/01-jm1/code/README.md
+++ b/solutions/typescript/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `bun (1.1)` installed locally
+1. Ensure you have `bun (1.2)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.ts`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/typescript/01-jm1/code/codecrafters.yml
+++ b/solutions/typescript/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the TypeScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: bun-1.1
-language_pack: bun-1.1
+# Available versions: bun-1.2
+language_pack: bun-1.2

--- a/solutions/typescript/02-rg2/code/codecrafters.yml
+++ b/solutions/typescript/02-rg2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the TypeScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: bun-1.1
-language_pack: bun-1.1
+# Available versions: bun-1.2
+language_pack: bun-1.2

--- a/solutions/typescript/02-rg2/diff/README.md.diff
+++ b/solutions/typescript/02-rg2/diff/README.md.diff
@@ -1,0 +1,32 @@
+@@ -4,30 +4,30 @@
+ ["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+ In this challenge, you'll build a toy Redis clone that's capable of handling
+ basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+ event loops, the Redis protocol and more.
+
+ **Note**: If you're viewing this repo on GitHub, head over to
+ [codecrafters.io](https://codecrafters.io) to try the challenge.
+
+ # Passing the first stage
+
+ The entry point for your Redis implementation is in `app/main.ts`. Study and
+ uncomment the relevant code, and push your changes to pass the first stage:
+
+ ```sh
+ git commit -am "pass 1st stage" # any msg
+ git push origin master
+ ```
+
+ That's all!
+
+ # Stage 2 & beyond
+
+ Note: This section is for stages 2 and beyond.
+
+-1. Ensure you have `bun (1.2)` installed locally
++1. Ensure you have `bun (1.1)` installed locally
+ 1. Run `./your_program.sh` to run your Redis server, which is implemented in
+    `app/main.ts`.
+ 1. Commit your changes and run `git push origin master` to submit your solution
+    to CodeCrafters. Test output will be streamed to your terminal.

--- a/starter_templates/elixir/code/.codecrafters/compile.sh
+++ b/starter_templates/elixir/code/.codecrafters/compile.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-# (This file is empty since Elixir programs don't use a compile step)
+mix escript.build
+mv codecrafters_redis /tmp/codecrafters-build-redis-elixir

--- a/starter_templates/elixir/code/.codecrafters/run.sh
+++ b/starter_templates/elixir/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec mix run --no-halt -- "$@"
+exec /tmp/codecrafters-build-redis-elixir "$@"

--- a/starter_templates/elixir/code/.gitignore
+++ b/starter_templates/elixir/code/.gitignore
@@ -1,3 +1,6 @@
+# Ignore the compiled binary
+/codecrafters_redis
+
 # The directory Mix will write compiled artifacts to.
 /_build/
 

--- a/starter_templates/elixir/code/lib/main.ex
+++ b/starter_templates/elixir/code/lib/main.ex
@@ -2,7 +2,7 @@ defmodule Server do
   @moduledoc """
   Your implementation of a Redis server
   """
-
+  
   use Application
 
   def start(_type, _args) do
@@ -22,5 +22,15 @@ defmodule Server do
     # # ensures that we don't run into 'Address already in use' errors
     # {:ok, socket} = :gen_tcp.listen(6379, [:binary, active: false, reuseaddr: true])
     # {:ok, _client} = :gen_tcp.accept(socket)
+  end
+end
+
+defmodule CLI do
+  def main(_args) do
+    # Start the Server application
+    {:ok, _pid} = Application.ensure_all_started(:codecrafters_redis)
+
+    # Run forever
+    Process.sleep(:infinity)
   end
 end

--- a/starter_templates/elixir/code/mix.exs
+++ b/starter_templates/elixir/code/mix.exs
@@ -4,17 +4,28 @@ defmodule App.MixProject do
 
   def project do
     [
-      app: :redis,
+      app: :codecrafters_redis,
       version: "1.0.0",
-      elixir: "~> 1.10",
-      start_permanent: Mix.env() == :prod
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      escript: [main_module: CLI]
     ]
   end
 
+  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger],
       mod: {Server, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]
   end
 end

--- a/starter_templates/elixir/config.yml
+++ b/starter_templates/elixir/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: mix
-  user_editable_file: lib/server.ex
+  required_executable: "mix"
+  user_editable_file: "lib/main.ex"

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.82)
+  required_executable: cargo (1.86)
   user_editable_file: src/main.rs

--- a/starter_templates/typescript/config.yml
+++ b/starter_templates/typescript/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: bun (1.1)
+  required_executable: bun (1.2)
   user_editable_file: app/main.ts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line interface entry point for Elixir projects, enabling execution via a compiled escript binary.
  - Introduced new Dockerfiles for updated Elixir, Rust, and Bun (TypeScript) environments.

- **Improvements**
  - Updated Elixir, Rust, and Bun/TypeScript starter templates and solutions to require newer language/runtime versions.
  - Enhanced build scripts to explicitly compile Elixir projects before execution.
  - Updated configuration files to reflect new entry points and version requirements.

- **Documentation**
  - Corrected and clarified entry point filenames and version requirements in README and documentation files.

- **Chores**
  - Updated `.gitignore` files to exclude new compiled binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->