### PR TITLE
chore: Update Zig Dockerfile to use Debian base image

### DIFF
--- a/dockerfiles/zig-0.14.Dockerfile
+++ b/dockerfiles/zig-0.14.Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.7-labs
-FROM alpine:3.20
+FROM debian:bookworm
 
-RUN apk add --no-cache 'xz>=5.6' 'curl>=8.9'
+RUN apt-get update && apt-get install -y xz-utils \
+    && rm -rf /var/lib/apt/lists/*
 
 # Download and install Zig
 RUN curl -O https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz \


### PR DESCRIPTION
- Changed base image from Alpine to Debian Bookworm for improved compatibility.
- Updated package installation command to use apt-get for xz-utils.