### PR TITLE
chore: Pin xz-utils version in Zig Dockerfile

### DIFF
--- a/dockerfiles/zig-0.14.Dockerfile
+++ b/dockerfiles/zig-0.14.Dockerfile
@@ -1,8 +1,10 @@
 # syntax=docker/dockerfile:1.7-labs
 FROM debian:bookworm
 
-RUN apt-get update && apt-get install -y xz-utils=5.8.1 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y xz-utils=5.4.1-1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Download and install Zig
 RUN curl -O https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz \

--- a/dockerfiles/zig-0.14.Dockerfile
+++ b/dockerfiles/zig-0.14.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7-labs
 FROM debian:bookworm
 
-RUN apt-get update && apt-get install -y xz-utils \
+RUN apt-get update && apt-get install -y xz-utils=5.8.1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and install Zig


### PR DESCRIPTION
- Updated the installation command in the Zig Dockerfile to specify the version of xz-utils as 5.8.1 for consistency and compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Reduced Docker image size by preventing installation of unnecessary recommended packages.
  - Ensured consistent builds by pinning the `xz-utils` package to a specific version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->