### PR TITLE
Fix Ruby Dockerfile dependency (libssl3) issue

### DIFF
--- a/dockerfiles/ruby-3.3.Dockerfile
+++ b/dockerfiles/ruby-3.3.Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:3.3-alpine
 # Required for installing the json/async gems
 RUN apk add --no-cache \
     build-base~=0.5 \
-    libssl3~=3.3 \
+    libssl3~=3.5 \
     readline-dev~=8.2 \
     zlib-dev~=1.3
 


### PR DESCRIPTION
Context:

- https://secure.helpscout.net/conversation/2956286378/8523?viewId=8414074
- https://secure.helpscout.net/conversation/2956653011/8527?viewId=8414074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the `libssl3` package used in the Ruby 3.3 Alpine image for improved compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->