### PR TITLE
Upgrade Scala version to 3.7.1 and update related configurations

### DIFF
--- a/compiled_starters/scala/.codecrafters/compile.sh
+++ b/compiled_starters/scala/.codecrafters/compile.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-sbt assembly
+# The option is needed for Java 17+ to allow native memory access operations.
+SBT_OPTS="--enable-native-access=ALL-UNNAMED" sbt assembly

--- a/compiled_starters/scala/.codecrafters/run.sh
+++ b/compiled_starters/scala/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec java -jar ./target/scala-2.13/redis.jar "$@"
+exec java -jar ./target/scala-3.7.1/redis.jar "$@"

--- a/compiled_starters/scala/build.sbt
+++ b/compiled_starters/scala/build.sbt
@@ -1,6 +1,6 @@
-ThisBuild / scalaVersion     := "2.13.12"
+ThisBuild / scalaVersion     := "3.7.1"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
-ThisBuild / organization     := "com.CodeCrafters"
+ThisBuild / organization     := "com.codecrafters"
 ThisBuild / organizationName := "CodeCrafters"
 
 assembly / assemblyJarName := "redis.jar"

--- a/compiled_starters/scala/codecrafters.yml
+++ b/compiled_starters/scala/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Scala version used to run your code
 # on Codecrafters.
 #
-# Available versions: scala-2.12
-language_pack: scala-2.12
+# Available versions: scala-3.7
+language_pack: scala-3.7

--- a/compiled_starters/scala/project/assembly.sbt
+++ b/compiled_starters/scala/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")

--- a/compiled_starters/scala/project/build.properties
+++ b/compiled_starters/scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.2

--- a/compiled_starters/scala/your_program.sh
+++ b/compiled_starters/scala/your_program.sh
@@ -14,11 +14,11 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
-  sbt assembly
+  SBT_OPTS="--enable-native-access=ALL-UNNAMED" sbt assembly
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec java -jar ./target/scala-2.13/redis.jar "$@"
+exec java -jar ./target/scala-3.7.1/redis.jar "$@"

--- a/dockerfiles/scala-3.7.Dockerfile
+++ b/dockerfiles/scala-3.7.Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM maven:3.9.9-eclipse-temurin-24-noble
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="build.sbt,project/assembly.sbt,project/build.properties"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
+
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list 
+
+RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import && \
+    chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends sbt=1.11.2 -yqq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/usr/local/sbt/bin:$PATH
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+WORKDIR /app
+
+RUN .codecrafters/compile.sh

--- a/solutions/scala/01-jm1/code/.codecrafters/compile.sh
+++ b/solutions/scala/01-jm1/code/.codecrafters/compile.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-sbt assembly
+# The option is needed for Java 17+ to allow native memory access operations.
+SBT_OPTS="--enable-native-access=ALL-UNNAMED" sbt assembly

--- a/solutions/scala/01-jm1/code/.codecrafters/run.sh
+++ b/solutions/scala/01-jm1/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec java -jar ./target/scala-2.13/redis.jar "$@"
+exec java -jar ./target/scala-3.7.1/redis.jar "$@"

--- a/solutions/scala/01-jm1/code/build.sbt
+++ b/solutions/scala/01-jm1/code/build.sbt
@@ -1,6 +1,6 @@
-ThisBuild / scalaVersion     := "2.13.12"
+ThisBuild / scalaVersion     := "3.7.1"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
-ThisBuild / organization     := "com.CodeCrafters"
+ThisBuild / organization     := "com.codecrafters"
 ThisBuild / organizationName := "CodeCrafters"
 
 assembly / assemblyJarName := "redis.jar"

--- a/solutions/scala/01-jm1/code/codecrafters.yml
+++ b/solutions/scala/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Scala version used to run your code
 # on Codecrafters.
 #
-# Available versions: scala-2.12
-language_pack: scala-2.12
+# Available versions: scala-3.7
+language_pack: scala-3.7

--- a/solutions/scala/01-jm1/code/project/assembly.sbt
+++ b/solutions/scala/01-jm1/code/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")

--- a/solutions/scala/01-jm1/code/project/build.properties
+++ b/solutions/scala/01-jm1/code/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.2

--- a/solutions/scala/01-jm1/code/your_program.sh
+++ b/solutions/scala/01-jm1/code/your_program.sh
@@ -14,11 +14,11 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
-  sbt assembly
+  SBT_OPTS="--enable-native-access=ALL-UNNAMED" sbt assembly
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec java -jar ./target/scala-2.13/redis.jar "$@"
+exec java -jar ./target/scala-3.7.1/redis.jar "$@"

--- a/starter_templates/scala/code/.codecrafters/compile.sh
+++ b/starter_templates/scala/code/.codecrafters/compile.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-sbt assembly
+# The option is needed for Java 17+ to allow native memory access operations.
+SBT_OPTS="--enable-native-access=ALL-UNNAMED" sbt assembly

--- a/starter_templates/scala/code/.codecrafters/run.sh
+++ b/starter_templates/scala/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec java -jar ./target/scala-2.13/redis.jar "$@"
+exec java -jar ./target/scala-3.7.1/redis.jar "$@"

--- a/starter_templates/scala/code/build.sbt
+++ b/starter_templates/scala/code/build.sbt
@@ -1,6 +1,6 @@
-ThisBuild / scalaVersion     := "2.13.12"
+ThisBuild / scalaVersion     := "3.7.1"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
-ThisBuild / organization     := "com.CodeCrafters"
+ThisBuild / organization     := "com.codecrafters"
 ThisBuild / organizationName := "CodeCrafters"
 
 assembly / assemblyJarName := "redis.jar"

--- a/starter_templates/scala/code/project/assembly.sbt
+++ b/starter_templates/scala/code/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")

--- a/starter_templates/scala/code/project/build.properties
+++ b/starter_templates/scala/code/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.2


### PR DESCRIPTION
- Changed the Scala version from 2.13.12 to 3.7.1 in build.sbt and codecrafters.yml files across multiple directories.
- Updated the organization name to use lowercase in build.sbt files.
- Modified the run scripts to reference the new jar file path for Scala 3.7.1.
- Added SBT_OPTS for native memory access in compile scripts.
- Upgraded sbt-assembly plugin version to 2.3.1 and sbt version to 1.11.2 in build properties.