### PR TITLE
chore: Update SBT version to 1.11.2 in README and configuration files

### DIFF
--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `sbt (1.9.9)` installed locally
+1. Ensure you have `sbt (1.11.2)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/scala/codecrafters_redis/Server.scala`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/scala/01-jm1/code/README.md
+++ b/solutions/scala/01-jm1/code/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `sbt (1.9.9)` installed locally
+1. Ensure you have `sbt (1.11.2)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/scala/codecrafters_redis/Server.scala`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/starter_templates/scala/config.yml
+++ b/starter_templates/scala/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: sbt (1.9.9)
+  required_executable: sbt (1.11.2)
   user_editable_file: src/main/scala/codecrafters_redis/Server.scala


### PR DESCRIPTION
- Changed the required SBT version from 1.9.9 to 1.11.2 in README.md files for compiled starters and solutions.
- Updated the required executable version in config.yml to reflect the new SBT version.