### PR TITLE
fix: use odin 2025-06 instead of 2025-04

### DIFF
--- a/compiled_starters/odin/codecrafters.yml
+++ b/compiled_starters/odin/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.4
-language_pack: odin-2025.4
+# Available versions: odin-2025.6
+language_pack: odin-2025.6

--- a/dockerfiles/odin-2025.6.Dockerfile
+++ b/dockerfiles/odin-2025.6.Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM silkeh/clang:19-bookworm
+
+WORKDIR /Odin-install
+RUN git clone --depth 1 -b dev-2025-06 https://github.com/odin-lang/Odin.git /Odin-install \
+    && git checkout dev-2025-06 \
+    && make
+
+RUN mkdir /opt/Odin \
+    && cp -R ./base ./core ./shared ./vendor ./odin /opt/Odin/
+
+WORKDIR /
+RUN rm -rf /Odin-install
+ENV PATH="/opt/Odin:${PATH}"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install language-specific dependencies
+RUN .codecrafters/compile.sh

--- a/solutions/odin/01-jm1/code/codecrafters.yml
+++ b/solutions/odin/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.4
-language_pack: odin-2025.4
+# Available versions: odin-2025.6
+language_pack: odin-2025.6


### PR DESCRIPTION
I had to bump the version of Odin to 2025-06 release.
The same code was not working in Odin-2025-04. Please see the screenshot below.

![Screenshot 2025-06-18 at 13 00 39](https://github.com/user-attachments/assets/eb56fb7f-da42-443f-8e0e-960cd9a22b30)

However, the Odin documentation states that the field `Would_Block` is indeed available. (https://pkg.odin-lang.org/core/net/#TCP_Recv_Error). 

As the Dockerfile for Odin was also updated on `language-templates` (https://github.com/codecrafters-io/language-templates/tree/main/languages/odin/dockerfiles), and the code works fine in Odin-2025-06, I think we should upgrade the version
