### PR TITLE
Change size-encoding to length-encoding

### DIFF
--- a/stage_descriptions/persistence-rdb-02-jz6.md
+++ b/stage_descriptions/persistence-rdb-02-jz6.md
@@ -103,33 +103,33 @@ FF                       /* Indicates that the file is ending,
 89 3b b7 4e f8 0f 77 19  // An 8-byte CRC64 checksum of the entire file.
 ```
 
-#### Size encoding
+#### Length encoding
 
-Size-encoded values specify the size of something. Here are some examples:
-- The database indexes and hash table sizes are size encoded.
-- String encoding begins with a size-encoded value that specifies the number of characters in the string.
-- List encoding begins with a size-encoded value that specifies the number of elements in the list.
+Length-encoded values specify the length or size of something. Here are some examples:
+- The database indexes and hash table sizes are length encoded.
+- String encoding begins with a length-encoded value that specifies the number of characters in the string.
+- List encoding begins with a length-encoded value that specifies the number of elements in the list.
 
-The first (most significant) two bits of a size-encoded value indicate how the value should be parsed. Here's a guide (bits are shown in both hexadecimal and binary):
+The first (most significant) two bits of a length-encoded value indicate how the value should be parsed. Here's a guide (bits are shown in both hexadecimal and binary):
 ```
 /* If the first two bits are 0b00:
-   The size is the remaining 6 bits of the byte.
-   In this example, the size is 10: */
+   The length is the remaining 6 bits of the byte.
+   In this example, the length is 10: */
 0A
 00001010
 
 /* If the first two bits are 0b01:
-   The size is the next 14 bits
+   The length is the next 14 bits
    (remaining 6 bits in the first byte, combined with the next byte),
    in big-endian (read left-to-right).
-   In this example, the size is 700: */
+   In this example, the length is 700: */
 42 BC
 01000010 10111100
 
 /* If the first two bits are 0b10:
    Ignore the remaining 6 bits of the first byte.
-   The size is the next 4 bytes, in big-endian (read left-to-right).
-   In this example, the size is 17000: */
+   The length is the next 4 bytes, in big-endian (read left-to-right).
+   In this example, the length is 17000: */
 80 00 00 42 68
 10000000 00000000 00000000 01000010 01101000
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology throughout the documentation, replacing "size encoding" with "length encoding" for improved clarity and consistency in explanations and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->