### PR TITLE
Clarify BLPOP timeout is specified in seconds

### DIFF
--- a/stage_descriptions/lists-11-xj7.md
+++ b/stage_descriptions/lists-11-xj7.md
@@ -12,7 +12,7 @@ It will then send a BLPOP command with a non-zero timeout:
 
 ```bash
 $ redis-cli BLPOP list_key 0.1
-# (Blocks for 0.1 second)
+# (Blocks for 0.1 seconds)
 ```
 
 After the timeout expires, the tester will expect to receive a null bulk string (`$-1\r\n`) as the response.

--- a/stage_descriptions/lists-11-xj7.md
+++ b/stage_descriptions/lists-11-xj7.md
@@ -12,7 +12,7 @@ It will then send a BLPOP command with a non-zero timeout:
 
 ```bash
 $ redis-cli BLPOP list_key 0.1
-# (Blocks)
+# (Blocks for 0.1 second)
 ```
 
 After the timeout expires, the tester will expect to receive a null bulk string (`$-1\r\n`) as the response.


### PR DESCRIPTION
Context:

<img width="588" height="290" alt="image" src="https://github.com/user-attachments/assets/30fc0ca6-0df4-48ee-b5c0-c940a6a9c079" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the description of the blocking duration for the `BLPOP` command to specify the exact timeout value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->