### PR TITLE
Revise "Query multiple streams using XREAD" (stage 28 - #ru9)

### DIFF
--- a/stage_descriptions/streams-10-ru9.md
+++ b/stage_descriptions/streams-10-ru9.md
@@ -1,4 +1,19 @@
-In this stage, you'll add extend support to `XREAD` to allow querying multiple streams.
+In this stage, you'll add support for querying multiple streams using the `XREAD` command.
+
+### The `XREAD` Command for Multiple Streams
+
+When reading from multiple streams, the `XREAD` command takes the `STREAMS` keyword, followed by a list of stream keys, and then a corresponding list of entry IDs for each stream.
+
+The command format is: 
+
+```bash
+XREAD STREAMS <key1> <key2> ... <id1> <id2> ...
+```
+
+The server's response remains a RESP array of streams where:
+
+- Each stream is a two-item array: the stream's key and the entries read from it.
+- The order of the streams in the response must match the order in which they were specified in the command.
 
 ### Tests
 
@@ -8,42 +23,22 @@ The tester will execute your program like this:
 $ ./your_program.sh
 ```
 
-First, an entry will be added to a couple of streams.
+It will then send multiple `XADD` commands to add entries to several streams.
 
 ```bash
 $ redis-cli XADD stream_key 0-1 temperature 95
 $ redis-cli XADD other_stream_key 0-2 humidity 97
 ```
 
-It'll then send an `XREAD` command to your server with multiple streams.
+Next, the tester will send an `XREAD` command to your server with multiple streams.
 
 ```bash
 $ redis-cli XREAD streams stream_key other_stream_key 0-0 0-1
 ```
 
-Your server should respond with the following:
+Your server should respond with a RESP array containing the results for all the specified streams.
 
-```text
-*2\r\n
-*2\r\n
-$10\r\nstream_key\r\n
-*1\r\n
-*2\r\n
-$3\r\n0-1\r\n
-*2\r\n
-$11\r\ntemperature\r\n
-$2\r\n95\r\n
-*2\r\n
-$16\r\nother_stream_key\r\n
-*1\r\n
-*2\r\n
-$3\r\n0-2\r\n
-*2\r\n
-$8\r\nhumidity\r\n
-$2\r\n97\r\n
-```
-
-This is the RESP encoded representation of the following.
+From the example above, your response should look like the following, encoded as a RESP array:
 
 ```json
 [
@@ -73,6 +68,3 @@ This is the RESP encoded representation of the following.
   ]
 ]
 ```
-
-### Notes
-- In the response, the items are separated onto new lines for readability. The tester expects all of these to be in one line.


### PR DESCRIPTION
Updated the description of the `XREAD` command to clarify its usage for querying multiple streams. Adjusted the examples and removed unnecessary notes for clarity.