### PR TITLE
Revise "Blocking reads without timeout" (stage 30 - #hw1)

### DIFF
--- a/stage_descriptions/streams-12-hw1.md
+++ b/stage_descriptions/streams-12-hw1.md
@@ -1,4 +1,4 @@
-In this stage, you'll extend your `XREAD` implementation to support indefinite blocking.
+In this stage, you'll extend your `XREAD` implementation to support blocking indefinitely.
 
 ### Indefinite Blocking in `XREAD`
 


### PR DESCRIPTION
Updated the documentation for the `XREAD` command to clarify the behavior of indefinite blocking without timeout.