### PR TITLE
Correct expected output for Redis RPUSH command

### DIFF
--- a/stage_descriptions/lists-09-jp1.md
+++ b/stage_descriptions/lists-09-jp1.md
@@ -34,7 +34,7 @@ It will first create a list with multiple elements.
 ```bash
 $ redis-cli
 > RPUSH list_key "one" "two" "three" "four" "five"
-# Expect: 4 (Resp Encoded Integer)
+# Expect: 5 (Resp Encoded Integer)
 ```
 
 After that, it will send your program an `LPOP` command with the number of elements to remove.


### PR DESCRIPTION
Update expected output for RPUSH command in Redis example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix expected RPUSH return value from 4 to 5 in `stage_descriptions/lists-09-jp1.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fca6a1781944adfabc782fa41ad2009de9b1c6cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->