### PR TITLE
Fix sentence format

### DIFF
--- a/stage_descriptions/base-03-wy1.md
+++ b/stage_descriptions/base-03-wy1.md
@@ -34,6 +34,6 @@ The tester will expect to receive a `+PONG\r\n` response for each command sent.
 
 ### Notes
 
-- The exact bytes your program will receive won't be just `PING`, you'll receive something like this: `*1\r\n$4\r\nPING\r\n`, which is the Redis protocol encoding of the `PING` command.
+- The exact bytes your program will receive won't be just `PING`. You'll receive something like this: `*1\r\n$4\r\nPING\r\n`, which is the Redis protocol encoding of the `PING` command.
 - Just like the previous stage, you can hardcode `+PONG\r\n` as the response for this stage. We'll get to parsing client input in later stages.
 - The tester will send the `PING` commands using the same connection. We'll get to handling multiple connections in later stages.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Rewords a note in `stage_descriptions/base-03-wy1.md` to split into two sentences clarifying the exact bytes for `PING`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd020779d08fa112de0f6ae951037f1c4b293481. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->