### PR TITLE
Fix LLEN sentence

### DIFF
--- a/stage_descriptions/lists-07-fv6.md
+++ b/stage_descriptions/lists-07-fv6.md
@@ -33,7 +33,7 @@ $ redis-cli
 > RPUSH list_key <random number of elements>
 ```
 
-Next, it will send a `LLEN` command for the newly created list. 
+Next, it will send an `LLEN` command for the newly created list. 
 
 ```bash
 > LLEN list_key


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes docs by adding backticks around LLEN in `stage_descriptions/lists-07-fv6.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0f6c99b06a6e752d632703239d3af956e995da5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->