### PR TITLE
Fix grammar in LPOP command stage

### DIFF
--- a/stage_descriptions/lists-08-ef1.md
+++ b/stage_descriptions/lists-08-ef1.md
@@ -44,5 +44,5 @@ The tester will also verify that the remaining elements are present in the list 
 
 ```bash
 > LRANGE list_key 0 -1
-# Expect RESP Encoded Array: ["two", "three", "four", "five"]
+# Expect a RESP Encoded Array: ["two", "three", "four", "five"]
 ``` 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix grammar in the LRANGE expectation comment in `stage_descriptions/lists-08-ef1.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1730964fb3e368b89887d913091bc940e2841bf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->