### PR TITLE
Fix formatting in lists-09-jp1.md

### DIFF
--- a/stage_descriptions/lists-09-jp1.md
+++ b/stage_descriptions/lists-09-jp1.md
@@ -34,7 +34,7 @@ It will first create a list with multiple elements.
 ```bash
 $ redis-cli
 > RPUSH list_key "one" "two" "three" "four" "five"
-# Expect: 5 (Resp Encoded Integer)
+# Expect: 5 (RESP Encoded Integer)
 ```
 
 After that, it will send your program an `LPOP` command with the number of elements to remove.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes RESP acronym casing in `stage_descriptions/lists-09-jp1.md` example output comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b85b5fabfcae8088895633d6888fec1c05bdc603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->