### PR TITLE
Fix wording for auto-generate sequence number

### DIFF
--- a/stage_descriptions/streams-04-yh3.md
+++ b/stage_descriptions/streams-04-yh3.md
@@ -6,7 +6,7 @@ As a recap, the `XADD` command accepts IDs in three formats:
 
 - Explicit (`1526919030473-0`) (Handled in the previous stage)
 - Auto-generate only the sequence number (`1526919030474-*`)
-- Auto-generate time part and sequence number (`*`)
+- Auto-generate the time part and sequence number (`*`)
 
 For this stage, you'll handle the second case, where only the sequence number is auto-generated.
 

--- a/stage_descriptions/streams-04-yh3.md
+++ b/stage_descriptions/streams-04-yh3.md
@@ -5,7 +5,7 @@ In this stage, you'll extend `XADD` to support auto-generating the sequence numb
 As a recap, the `XADD` command accepts IDs in three formats:
 
 - Explicit (`1526919030473-0`) (Handled in the previous stage)
-- Auto-generate only sequence number (`1526919030474-*`)
+- Auto-generate only the sequence number (`1526919030474-*`)
 - Auto-generate time part and sequence number (`*`)
 
 For this stage, you'll handle the second case, where only the sequence number is auto-generated.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies wording and bullet formatting for XADD ID auto-generation cases in `stage_descriptions/streams-04-yh3.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa77bf9da43285a915dcbaea2f7032d27d53f5c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->