### PR TITLE
Fix formatting of entry ID descriptions

### DIFF
--- a/stage_descriptions/streams-05-xu6.md
+++ b/stage_descriptions/streams-05-xu6.md
@@ -5,8 +5,8 @@ In this stage, you'll extend `XADD` to support auto-generating entry IDs.
 As a recap, the `XADD` command accepts IDs in three formats:
 
 - Explicit (`1526919030473-0`) (Handled in an earlier stage)
-- Auto-generate only sequence number (`1526919030474-*`) (Handled in the previous stage)
-- Auto-generate time part and sequence number (`*`)
+- Auto-generate only the sequence number (`1526919030474-*`) (Handled in the previous stage)
+- Auto-generate the time part and sequence number (`*`)
 
 For this stage, you'll handle the third case, where the entire entry ID is auto-generated.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes the XADD entry ID options list formatting in `stage_descriptions/streams-05-xu6.md` to correctly show the two auto-generate variants as bullets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d318660e5b3e881f836ba4ac84618873654135f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->