### PR TITLE
Update comment for clarity on return value format

### DIFF
--- a/stage_descriptions/streams-09-um0.md
+++ b/stage_descriptions/streams-09-um0.md
@@ -76,7 +76,7 @@ $2\r\n37\r\n
 $8\r\nhumidity\r\n
 $2\r\n94\r\n
 ```
-(*The lines are separated into new lines for readability. The actual return value is just one line.*)
+(*The result is shown on separate lines for readability. The actual return value is a single line.*)
 
 ### Tests
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies that the RESP example is shown on separate lines for readability and the actual return is a single line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc605b7a6538b7aa935a37fa9a011976f8d65287. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->