### PR TITLE
Revise "The INFO command" (stage 44 - #ye5)

### DIFF
--- a/stage_descriptions/replication-02-ye5.md
+++ b/stage_descriptions/replication-02-ye5.md
@@ -1,10 +1,32 @@
-In this stage, you'll add support for responding to the [INFO](https://redis.io/commands/info/) command as a master.
+In this stage, you'll add support for responding to the [INFO](https://redis.io/commands/info/) command as a master server.
 
-The `INFO` command returns information and statistics about a Redis server. In this stage, we'll add support for the `replication` section of the `INFO` command.
+### The `INFO` Command
 
-### The replication section
+The `INFO` command returns information and statistics about a running Redis server. For example, a client can get information about a server like this:
 
-When you run the `INFO` command against a Redis server, you'll see something like this:
+```bash
+$ redis-cli INFO
+# Server
+redis_version:7.2.4
+...
+# Clients
+connected_clients:1
+...
+# Memory
+used_memory:859944
+...
+# Replication
+role:master
+...
+```
+
+The server then responds with a [bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings), where each line is a key-value pair separated by a colon (`:`). The string can also contain section header lines (starting with `#`) and blank lines.
+
+The `INFO` command also accepts an optional parameter to specify which section of information to display, such as `server`, `memory`, or `replication`. For this stage, we'll only focus on the `replication` section.
+
+### The `replication` Section
+
+When you run the `INFO` command with the `replication` argument, the server returns only the details concerning its replication setup:
 
 ```
 $ redis-cli INFO replication
@@ -20,14 +42,12 @@ repl_backlog_first_byte_offset:0
 repl_backlog_histlen:
 ```
 
-The reply to this command is a [Bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) where each line is a key value pair, separated by ":".
-
 Here are what some of the important fields mean:
 
-- `role`: The role of the server (`master` or `slave`)
-- `connected_slaves`: The number of connected replicas
-- `master_replid`: The replication ID of the master (we'll get to this in later stages)
-- `master_repl_offset`: The replication offset of the master (we'll get to this in later stages)
+- `role`: The role of the server (either `master` or `slave`).
+- `connected_slaves`: The number of connected replica servers.
+- `master_replid`: The replication ID of the master.
+- `master_repl_offset`: The replication offset of the master.
 
 In this stage, you'll only need to support the `role` key. We'll add support for other keys in later stages.
 
@@ -39,20 +59,18 @@ The tester will execute your program like this:
 ./your_program.sh --port <PORT>
 ```
 
-It'll then send the `INFO` command with `replication` as an argument.
+It will then send the `INFO` command with `replication` as an argument.
 
 ```bash
 $ redis-cli -p <PORT> info replication
 ```
 
-Your program should respond with a [Bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) where each line
-is a key value pair separated by `:`. The tester will only look for the `role` key, and assert that the value is `master`.
+Your server should respond with a [bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) where each line
+is a key value pair separated by a colon (`:`). The tester will only look for the `role` key and assert that the value is `master`.
 
 ### Notes
 
 - In the response for the `INFO` command, you only need to support the `role` key for this stage. We'll add support for the other keys in later stages.
-- The `# Replication` heading in the response is optional, you can ignore it.
-- The response to `INFO` needs to be encoded as a [Bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings).
-  - An example valid response would be `$11\r\nrole:master\r\n` (the string `role:master` encoded as a [Bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings))
-- The `INFO` command can be used without any arguments, in which case it returns all sections available. In this stage, we'll
-  always send `replication` as an argument to the `INFO` command, so you only need to support the `replication` section.
+- The `# Replication` heading in the response is optional, and you can ignore it.
+- The response to `INFO` needs to be encoded as a bulk string.
+  - An example valid response would be `$11\r\nrole:master\r\n` (the string `role:master` encoded as a bulk string)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the replication stage docs by adding a general INFO overview, clearer examples, and precise bulk string/formatting guidance, keeping focus on the role key.
> 
> - **Docs update** in `stage_descriptions/replication-02-ye5.md`:
>   - Add a new overview section for the `INFO` command with example full output and explanation of bulk string format and sections.
>   - Refine the replication example and field descriptions; clarify that only the `role` key needs to be supported.
>   - Improve test instructions and notes: specify argument usage, colon-separated key-value format, and bulk string encoding (with example).
>   - Minor wording/consistency tweaks (e.g., “master server”, optional `# Replication` header).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fd65079f553d69a67167de55b36c0c7c0804973. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->