### PR TITLE
Revise "Initial replication ID and offset #xc1" (stage 46)

### DIFF
--- a/stage_descriptions/replication-04-xc1.md
+++ b/stage_descriptions/replication-04-xc1.md
@@ -1,22 +1,19 @@
 In this stage, you'll extend your `INFO` command to return two additional values: `master_replid` and `master_repl_offset`.
 
-### The replication ID and offset
+### The Replication ID and Offset
 
-Every Redis master has a replication ID: it is a large pseudo random string. This is set when the master is booted. Every time
-a master instance restarts from scratch, its replication ID is reset.
+Every Redis master has a **replication ID**: a 40-character pseudo-random alphanumeric string that identifies the replication stream. This ID is generated when the master starts and resets each time the master restarts from scratch.
 
-Each master also maintains a "replication offset" corresponding to how many bytes of commands have been added to the replication
-stream. We'll learn more about this offset in later stages. For now, just know that the value starts from `0` when a master is
-booted and no replicas have connected yet.
+Each master also maintains a **replication offset** that tracks how many bytes of commands have been sent to replicas. The offset starts at `0` when a master boots up and no replicas have connected yet.
 
-In this stage, you'll initialize a replication ID and offset for your master:
+In this stage, you'll initialize a replication ID and replication offset for the master server:
 
-- The ID can be any pseudo random alphanumeric string of 40 characters.
-  - For the purposes of this challenge, you don't need to actually generate a random string, you can hardcode it instead.
+- The ID can be any pseudo-random alphanumeric string of 40 characters.
+  - For the purposes of this challenge, you don't need to generate a random string. You can hardcode it instead.
   - As an example, you can hardcode `8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb` as the replication ID.
-- The offset is to be 0.
+- The offset should be `0`.
 
-These two values should be returned as part of the INFO command output, under the `master_replid` and `master_repl_offset` keys respectively.
+These two values should be returned as part of the `INFO` command output, under the `master_replid` and `master_repl_offset` keys, respectively.
 
 ### Tests
 
@@ -26,18 +23,18 @@ The tester will execute your program like this:
 ./your_program.sh
 ```
 
-It'll then send the `INFO` command with `replication` as an argument to your server.
+It will then send the `INFO` command with the `replication` option to your server.
 
 ```bash
 $ redis-cli INFO replication
 ```
 
-Your program should respond with a [Bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) where each line
-is a key value pair separated by `:`. The tester will look for the following keys:
+Your program should respond with a [bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) where each line is a key-value pair separated by a colon (`:`). The tester will look for the following key-value pairs:
 
-- `master_replid`, which should be a 40 character alphanumeric string
-- `master_repl_offset`, which should be `0`
+- `role`: `master`
+- `master_replid`: A 40-character alphanumeric string
+- `master_repl_offset`: `0`
 
 ### Notes
 
-- Your code should still pass the previous stage tests, so the `role` key still needs to be returned
+- Your code must pass previous stage tests, meaning you should still return the correct `role` key.

--- a/stage_descriptions/replication-04-xc1.md
+++ b/stage_descriptions/replication-04-xc1.md
@@ -1,15 +1,17 @@
-In this stage, you'll extend your `INFO` command to return two additional values: `master_replid` and `master_repl_offset`.
+In this stage, you'll extend your `INFO` command to return the `master_replid` and `master_repl_offset` values.
 
 ### The Replication ID and Offset
 
-Every Redis master has a **replication ID**: a 40-character pseudo-random alphanumeric string that identifies the replication stream. This ID is generated when the master starts and resets each time the master restarts from scratch.
+Every Redis master maintains two key pieces of information for managing replication: the **replication ID** and the **replication offset**.
 
-Each master also maintains a **replication offset** that tracks how many bytes of commands have been sent to replicas. The offset starts at `0` when a master boots up and no replicas have connected yet.
+The replication ID is a large pseudo-random string. This ID identifies the current history of the master's dataset. When a master device is booted for the first time or restarted, it resets its ID.
 
-In this stage, you'll initialize a replication ID and replication offset for the master server:
+The replication offset tracks the number of bytes of commands the master has streamed to its replicas. This value is used to update the state of the replicas with changes made to the dataset. The offset starts at `0` when a master boots up and no replicas have connected yet.
 
-- The ID can be any pseudo-random alphanumeric string of 40 characters.
-  - For the purposes of this challenge, you don't need to generate a random string. You can hardcode it instead.
+In this stage, you'll initialize a replication ID and offset for the master server:
+
+- The ID can be any pseudo-random alphanumeric string of `40` characters.
+  - For this challenge, you don't need to generate a random string. You can hardcode it instead.
   - As an example, you can hardcode `8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb` as the replication ID.
 - The offset should be `0`.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the replication stage doc to clarify replication ID/offset, expected INFO replication output (including role), and phrasing/formatting.
> 
> - **Docs** (`stage_descriptions/replication-04-xc1.md`):
>   - Clarifies definitions of `replication ID` and `replication offset`, capitalization, and phrasing.
>   - Tightens instructions for initializing values (40-char pseudo-random ID, offset `0`).
>   - Updates test expectations for `INFO replication` to list required keys, now explicitly including `role`.
>   - Improves wording/formatting (backticks, hyphenation, “bulk string”, colon-separated key-value pairs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d78f0aae1a0ded76611675b7fc1ebd7c49e88387. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->