### PR TITLE
Revise "Send handshake (1/3) #gl7" (stage 47)

### DIFF
--- a/stage_descriptions/replication-05-gl7.md
+++ b/stage_descriptions/replication-05-gl7.md
@@ -12,7 +12,7 @@ There are three parts to this handshake:
 
 We'll learn more about `REPLCONF` and `PSYNC` in later stages. For now, we'll focus on the first part of the handshake.
 
-When your server starts in replica mode, it must immediately connect to the specified master host and port, and then send the `PING` command.
+When your server starts in replica mode, it must connect to the specified master host and port, and then send the `PING` command.
 
 The `PING` command must be sent encoded as a [RESP array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays).
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines replication stage docs to clearly outline handshake step 1 and require sending PING as a RESP array, with restructured headings and tests.
> 
> - **Docs (replication-05-gl7)**:
>   - Clarify the handshake by renaming the heading and converting steps to a numbered list.
>   - Specify that on replica start, it connects to the master and sends `PING` encoded as a RESP array (`*1\r\n$4\r\nPING\r\n`).
>   - Consolidate instructions into the Tests section, stating the tester expects a RESP-array `PING`; remove the separate Notes section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4af425873f6aab166174c279b2adf027f2c1943f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->