### PR TITLE
Revise "Send handshake (3/3) #ju6" (stage 49)

### DIFF
--- a/stage_descriptions/replication-07-ju6.md
+++ b/stage_descriptions/replication-07-ju6.md
@@ -51,5 +51,5 @@ It will then assert that the replica connects to the master and sends the follow
 
 1. `PING`
 2. `REPLCONF` with `listening-port` and `<PORT>` as arguments
-3. `REPLCONF` with `capa eof capa psync2` as arguments
+3. `REPLCONF` with `capa psync2` as arguments
 4. `PSYNC` with `? -1` as arguments


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the replication handshake docs by clarifying PSYNC usage/format and updating test expectations for step 3.
> 
> - **Docs** (`stage_descriptions/replication-07-ju6.md`):
>   - **Handshake recap**: Reworded intro and headings for step 3 of replication handshake.
>   - **PSYNC details**: Added dedicated section with command format (`PSYNC <replication_id> <offset>`), clarified first-connection args (`?` and `-1`), and kept RESP array example.
>   - **Master response**: Clarified simple string response and noted it can be ignored for now.
>   - **Tests**: Reformatted to an explicit ordered list of expected commands and arguments (`PING`, `REPLCONF listening-port <PORT>`, `REPLCONF capa psync2`, `PSYNC ? -1`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a98a9b1f0afea1a9660a31c88812ffd20590b62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->