### PR TITLE
Revise "Receive handshake (1/2) #fj0" (stage 50)

### DIFF
--- a/stage_descriptions/replication-08-fj0.md
+++ b/stage_descriptions/replication-08-fj0.md
@@ -4,7 +4,7 @@ In this stage, we'll start implementing support for receiving a replication hand
 
 Up until now, we've been implementing the handshake from the replica's perspective. Now we'll implement the same handshake on the master side.
 
-As a recap, the master receives:
+As a recap, the master receives the following for the handshake process:
 
 1. A `PING` from the replica
 2. `REPLCONF` twice from the replica

--- a/stage_descriptions/replication-08-fj0.md
+++ b/stage_descriptions/replication-08-fj0.md
@@ -1,10 +1,10 @@
 In this stage, we'll start implementing support for receiving a replication handshake as a master.
 
-### The Handshake Process (Recap)
+### Handshake (Recap)
 
 Up until now, we've been implementing the handshake from the replica's perspective. Now we'll implement the same handshake on the master side.
 
-As a recap, the master receives the following from the replica during the handshake process:
+As a recap, the master receives the following from the replica during the handshake:
 
 1. A `PING` command
 2. Two `REPLCONF` commands
@@ -26,6 +26,6 @@ The tester will execute your program like this:
 
 It will then send the following commands:
 
-1. `PING` — expecting `+PONG\r\n` as the response
+1. `PING` — expecting `+PONG\r\n`
 2. `REPLCONF listening-port <PORT>` — expecting `+OK\r\n`
 3. `REPLCONF capa psync2` — expecting `+OK\r\n` 

--- a/stage_descriptions/replication-08-fj0.md
+++ b/stage_descriptions/replication-08-fj0.md
@@ -1,20 +1,20 @@
 In this stage, we'll start implementing support for receiving a replication handshake as a master.
 
-### Handshake (continued from previous stage)
+### The Handshake Process (Recap)
 
-We'll now implement the same handshake we did in the previous stages, but on the master instead of the replica.
+Up until now, we've been implementing the handshake from the replica's perspective. Now we'll implement the same handshake on the master side.
 
-As a recap, there are three parts to the handshake:
+As a recap, the master receives:
 
-- The master receives a `PING` from the replica
-  - Your Redis server already supports the `PING` command, so there's no additional work to do here
-- The master receives `REPLCONF` twice from the replica (**This stage**)
-- The master receives `PSYNC` from the replica (Next stage)
+1. A `PING` from the replica
+2. `REPLCONF` twice from the replica
+3. `PSYNC` from the replica
 
-In this stage, you'll add support for receiving the `REPLCONF` command from the replica.
+Your Redis server already supports the `PING` command, so there's no additional work to do for the first part.
 
-You'll receive `REPLCONF` twice from the replica. For the purposes of this challenge, you can safely ignore the arguments for both commands and just
-respond with `+OK\r\n` ("OK" encoded as a RESP Simple String).
+In this stage, you'll add support for receiving the `REPLCONF` command from the replica as a master.
+
+You'll receive `REPLCONF` twice from the replica. For the purposes of this challenge, you can safely ignore the arguments for both commands and simply respond with `+OK\r\n`. That's the string `OK` encoded as a [simple string](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
 
 ### Tests
 
@@ -24,8 +24,8 @@ The tester will execute your program like this:
 ./your_program.sh --port <PORT>
 ```
 
-It'll then send the following commands:
+It will then send the following commands:
 
-1. `PING` (expecting `+PONG\r\n` back)
-2. `REPLCONF listening-port <PORT>` (expecting `+OK\r\n` back)
-3. `REPLCONF capa psync2` (expecting `+OK\r\n` back)
+1. `PING` — expecting `+PONG\r\n` as the response
+2. `REPLCONF listening-port <PORT>` — expecting `+OK\r\n`
+3. `REPLCONF capa psync2` — expecting `+OK\r\n` 

--- a/stage_descriptions/replication-08-fj0.md
+++ b/stage_descriptions/replication-08-fj0.md
@@ -4,17 +4,17 @@ In this stage, we'll start implementing support for receiving a replication hand
 
 Up until now, we've been implementing the handshake from the replica's perspective. Now we'll implement the same handshake on the master side.
 
-As a recap, the master receives the following for the handshake process:
+As a recap, the master receives the following from the replica during the handshake process:
 
-1. A `PING` from the replica
-2. `REPLCONF` twice from the replica
-3. `PSYNC` from the replica
+1. A `PING` command
+2. Two `REPLCONF` commands
+3. A `PSYNC` command
 
-Your Redis server already supports the `PING` command, so there's no additional work to do for the first part.
+Your Redis server already supports the `PING` command, so there's no additional work to do for the first step.
 
-In this stage, you'll add support for receiving the `REPLCONF` command from the replica as a master.
+In this stage, you'll add support for receiving the two `REPLCONF` commands as a master.
 
-You'll receive `REPLCONF` twice from the replica. For the purposes of this challenge, you can safely ignore the arguments for both commands and simply respond with `+OK\r\n`. That's the string `OK` encoded as a [simple string](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
+For the purposes of this challenge, you can safely ignore the arguments for both commands and simply respond with `+OK\r\n`. That's the string `OK` encoded as a [simple string](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
 
 ### Tests
 


### PR DESCRIPTION
Updated the description of the handshake process for clarity and consistency. Adjusted the format and details of the commands received by the master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the master-side replication handshake docs with a concise step list and updated test command expectations.
> 
> - **Documentation**:
>   - **Handshake (Recap)**:
>     - Reframes content from the master's perspective and renames section to `Handshake (Recap)`.
>     - Clarifies steps as a numbered list: `PING`, two `REPLCONF`, then `PSYNC`; notes `PING` needs no changes.
>     - Specifies responding `+OK\r\n` to both `REPLCONF` commands; adds reference to RESP simple strings.
>   - **Tests**:
>     - Rewords and formats the command sequence and expected responses (`PING`, `REPLCONF listening-port`, `REPLCONF capa psync2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9310d04ce60d854cb424bdafa603059f00bd6874. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->