### PR TITLE
Update terminology from 'slave' to 'replica'

### DIFF
--- a/stage_descriptions/replication-03-hc6.md
+++ b/stage_descriptions/replication-03-hc6.md
@@ -2,7 +2,7 @@ In this stage, you'll extend the [INFO](https://redis.io/commands/info/) command
 
 ### The `--replicaof` Flag
 
-By default, your Redis server assumes the master role. When you pass the `--replicaof` flag, the server assumes the slave role instead.
+By default, your Redis server assumes the master role. When you pass the `--replicaof` flag, the server assumes the replica role instead.
 
 For example:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates replication docs to say the server assumes the replica role (not slave) when using --replicaof.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 960175df685d868bcb7580ebf22aa1812d207950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->