### PR TITLE
Clarify language in replication handshake description

### DIFF
--- a/stage_descriptions/replication-05-gl7.md
+++ b/stage_descriptions/replication-05-gl7.md
@@ -1,10 +1,10 @@
-In this stage, you'll implement the first part of the replication handshake.
+In this stage, you'll implement the first step of the replication handshake.
 
 ### The Handshake Process
 
 When a replica connects to a master, it needs to go through a handshake process before receiving updates from the master.
 
-There are three parts to this handshake:
+There are three steps to this handshake:
 
 1. The replica sends a `PING` to the master.
 2. The replica sends `REPLCONF` twice to the master.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies the replication handshake description by changing "first part" to "first step" and "three parts" to "three steps" in `stage_descriptions/replication-05-gl7.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5997debbb19a64303cc293ae73c0baa52630073. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->