### PR TITLE
Revise "Single-replica propagation #zn8" (stage 53)

### DIFF
--- a/stage_descriptions/replication-11-zn8.md
+++ b/stage_descriptions/replication-11-zn8.md
@@ -38,7 +38,10 @@ $ redis-cli SET bar 2
 $ redis-cli SET baz 3
 ```
 
-It will then assert that these commands were propagated to the replica in the correct order. The tester will expect to receive these commands encoded as RESP arrays and sent on the replication connection (the one used for the handshake).
+It will then assert that these commands were propagated to the replica in the correct order. The tester will expect to receive these commands: 
+
+- Encoded as RESP arrays.
+- Sent on the same connection used for the handshake (replication connection).
 
 ### Notes
 


### PR DESCRIPTION
Updated command propagation section for clarity and consistency. Revised descriptions of write commands and their propagation process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies replication docs for write-command propagation over the replication connection, streamlines the tests section, and tightens notes/wording.
> 
> - **Docs (replication-11-zn8.md)**:
>   - **Command Propagation**: Clarifies that only write commands (e.g., `SET`, `DEL`) are propagated; non-write commands (e.g., `PING`, `ECHO`) are not.
>   - **Propagation Process**: Refines explanation that commands are sent as RESP arrays over the same replication connection; replicas process without responding; mentions `REPLCONF GETACK` as the exception.
>   - **Tests**: Replaces step-by-step handshake list with a concise reference to the full handshake; specifies verification that write commands are received in order, as RESP arrays, on the replication connection.
>   - **Notes**: Tightens wording and formatting; emphasizes use of the replica-initiated TCP connection and buffering assumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41cacf64179e3ac55fec766349d431f39fe89cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->