### PR TITLE
Revise "Multi-replica propagation #hd5" (stage 54)

### DIFF
--- a/stage_descriptions/replication-12-hd5.md
+++ b/stage_descriptions/replication-12-hd5.md
@@ -14,7 +14,7 @@ The tester will execute your program like this:
 ./your_program.sh --port <PORT>
 ```
 
-It will then start **multiple** replicas that will each connect to your server, complete the handshake sequence (`PING`, `REPLCONF`, `PSYNC`), and receive the initial RDB file.
+It will then start **multiple** replicas that will each connect to your server, complete the handshake sequence, and receive the initial RDB file.
 
 Next, the tester will send `SET` commands to the master from a separate client.
 

--- a/stage_descriptions/replication-12-hd5.md
+++ b/stage_descriptions/replication-12-hd5.md
@@ -14,7 +14,7 @@ The tester will execute your program like this:
 ./your_program.sh --port <PORT>
 ```
 
-It will then start **multiple** replicas that will each connect to your server, complete the handshake sequence, and receive the initial RDB file.
+It will then start **multiple** replicas that will each connect to your server, complete the handshake, and receive the initial RDB file.
 
 Next, the tester will send `SET` commands to the master from a separate client.
 

--- a/stage_descriptions/replication-12-hd5.md
+++ b/stage_descriptions/replication-12-hd5.md
@@ -1,5 +1,11 @@
 In this stage, you'll extend your implementation of the master to support propagating commands to multiple replicas.
 
+### Command Propagation
+
+Once a replica completes the handshake and loads the RDB file, it is ready to start receiving live updates from the master. 
+
+Every write command executed on the master must be forwarded to all connected replicas, not just one. This ensures that every replica stays in sync with the master.
+
 ### Tests
 
 The tester will execute your program like this:
@@ -8,16 +14,9 @@ The tester will execute your program like this:
 ./your_program.sh --port <PORT>
 ```
 
-It'll then start **multiple** replicas that connect to your server and execute the following commands:
+It will then start **multiple** replicas that will each connect to your server, complete the handshake sequence (`PING`, `REPLCONF`, `PSYNC`), and receive the initial RDB file.
 
-1. `PING` (expecting `+PONG\r\n` back)
-2. `REPLCONF listening-port <PORT>` (expecting `+OK\r\n` back)
-3. `REPLCONF capa psync2` (expecting `+OK\r\n` back)
-4. `PSYNC ? -1` (expecting `+FULLRESYNC <REPL_ID> 0\r\n` back)
-
-Each replica will expect to receive an RDB file from the master after the handshake is complete.
-
-It'll then send `SET` commands to the master from a client (a separate Redis client, not the replicas).
+Next, the tester will send `SET` commands to the master from a separate client.
 
 ```bash
 $ redis-cli SET foo 1
@@ -25,4 +24,4 @@ $ redis-cli SET bar 2
 $ redis-cli SET baz 3
 ```
 
-It'll then assert that each replica received those commands, in order.
+It will then assert that each replica received those commands in the correct order.

--- a/stage_descriptions/replication-12-hd5.md
+++ b/stage_descriptions/replication-12-hd5.md
@@ -1,6 +1,6 @@
 In this stage, you'll extend your implementation of the master to support propagating commands to multiple replicas.
 
-### Command Propagation
+### Command Propagation (Recap)
 
 Once a replica completes the handshake and loads the RDB file, it is ready to start receiving live updates from the master. 
 


### PR DESCRIPTION
Clarify command propagation and testing process for replicas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines `replication-12-hd5` docs with a propagation recap and streamlined test description emphasizing multi-replica handshake, RDB, and ordered command forwarding.
> 
> - **Docs**:
>   - **`stage_descriptions/replication-12-hd5.md`**:
>     - Add “Command Propagation (Recap)” explaining forwarding all master writes to all replicas post-handshake/RDB.
>     - Simplify tests section: describe multiple replicas completing handshake, receiving RDB, then verifying ordered `SET` propagation, replacing step-by-step command list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 443d87d8026f8f6c8051a9e8d39c16e57c8b4736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->