### PR TITLE
Refactor handshake process descriptions in markdown

### DIFF
--- a/stage_descriptions/replication-06-eh4.md
+++ b/stage_descriptions/replication-06-eh4.md
@@ -1,14 +1,14 @@
 In this stage, you'll implement the second step of the replication handshake.
 
-### The Handshake Process (Recap)
+### Handshake (Recap)
 
-As a recap, there are three steps to the handshake process:
+As a recap, there are three steps to the handshake:
 
 1. The replica sends a `PING` to the master (Handled in the previous stage)
 2. The replica sends `REPLCONF` twice to the master
 3. The replica sends `PSYNC` to the master
 
-For this stage, you'll handle the second part of this process.
+For this stage, you'll handle the second step of this process.
 
 ### The `REPLCONF` Command
 
@@ -17,7 +17,7 @@ The `REPLCONF` command is used to configure a connected replica. After receiving
 1. `REPLCONF listening-port <PORT>`: This tells the master which port the replica is listening on. This value is used for [monitoring and logging](https://github.com/redis/redis/blob/90178712f6eccf1e5b61daa677c5c103114bda3a/src/replication.c#L107-L130), not for replication itself.
 2. `REPLCONF capa psync2`: This notifies the master of the replica's capabilities.
    - `capa` stands for "capabilities". It indicates that the next argument is a feature the replica supports.
-   - `psync2` signals that the replica supports the PSYNC 2.0 protocol, which is an improved version of the [partial synchronization](https://redis.io/docs/latest/operate/oss_and_stack/management/replication/) feature used to resynchronize a replica with its master.
+   - `psync2` signals that the replica supports the PSYNC2 protocol. PSYNC2 is an improved version of the [partial synchronization](https://redis.io/docs/latest/operate/oss_and_stack/management/replication/) feature used to resynchronize a replica with its master.
    - You can safely hardcode `capa psync2` for now.
 
 Both commands should be sent as RESP arrays, so the exact bytes will look something like this:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines replication handshake docs: updates headings/phrasing and clarifies PSYNC2 terminology in `stage_descriptions/replication-06-eh4.md`.
> 
> - **Documentation** (`stage_descriptions/replication-06-eh4.md`):
>   - Rename heading to `Handshake (Recap)` and simplify phrasing (e.g., “handshake process” → “handshake”, “second part” → “second step”).
>   - Clarify capability description: refer to PSYNC2 consistently and explain it as the improved partial sync protocol.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bee821acf703e2349edf931a3edc2396335dbbc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->