### PR TITLE
Revise "Command processing #yg4" (stage 55)

### DIFF
--- a/stage_descriptions/replication-13-yg4.md
+++ b/stage_descriptions/replication-13-yg4.md
@@ -2,9 +2,12 @@ In this stage, you'll implement the processing of propagated commands as a repli
 
 ### Command Processing
 
-After the replica receives a command from the master, it processes it and applies it to its own state. This will work exactly like a regular command sent by a client, except that the replica doesn't send a response back to the master.
+After the replica receives a command from the master, it processes it and applies it to its own state. This will work exactly like a regular command sent by a client. The key difference is that the replica **must not send a response** back to the master.
 
-For example, if a master propagates a `SET foo 1` command to a replica, the replica must update its database to set the value of `foo` to `1`. Unlike commands from a regular client though, it must not reply with `+OK\r\n`.
+For example, if a master propagates `SET foo 1` to a replica:
+
+- The replica must update its database to set the value of `foo` to `1`.
+- Unlike commands from regular clients, the replica does not reply with `+OK\r\n`.
 
 ### Tests
 
@@ -16,7 +19,7 @@ The tester will spawn a Redis master and execute your program as a replica like 
 
 Just like in the previous stages, your replica should complete the handshake with the master and receive an empty RDB file.
 
-Once the RDB file is received, the master will propagate a series of write commands to your program.
+Once the RDB file is received, the master will propagate a series of write commands to your program:
 
 ```bash
 SET foo 1 # propagated from master to replica
@@ -35,4 +38,4 @@ $ redis-cli GET bar # expecting `2` back
 ### Notes
 
 - The propagated commands are sent as RESP arrays. So the command `SET foo 1` will be sent as `*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$1\r\n1\r\n`.
-- It is **not** guaranteed that propagated commands will be sent one at a time. One "TCP segment" might contain bytes for multiple commands.
+- It is **not** guaranteed that propagated commands will be sent one at a time. One TCP segment might contain bytes for multiple commands.


### PR DESCRIPTION
Correct grammatical errors and improve clarity in the stage description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies and tightens the replica command processing stage description, emphasizing no responses and refining examples/notes.
> 
> - **Documentation**:
>   - Updates `stage_descriptions/replication-13-yg4.md`:
>     - Clarifies replica behavior: apply propagated commands and do not send responses to the master.
>     - Improves grammar, capitalization, and concision; restructures example as bullets.
>     - Tweaks test/notes wording (RESP arrays example; TCP segment note).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c5e4b998db22e76f5e8569acbebcfb17a1d0c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->