### PR TITLE
Revise "ACKs with no commands #xv6" (stage 56)

### DIFF
--- a/stage_descriptions/replication-14-xv6.md
+++ b/stage_descriptions/replication-14-xv6.md
@@ -1,42 +1,28 @@
-In this stage you'll implement support for responding to the `REPLCONF GETACK` command as a replica.
+In this stage, you'll implement support for responding to the `REPLCONF GETACK` command as a replica.
 
 ### ACKs
 
-<details>
-  <summary>Click to expand/collapse</summary>
+Unlike regular commands, when a master forwards commands to a replica via the replication connection, the replica doesn't respond to each command. It just silently processes the commands and updates its state.
 
-  Unlike regular commands, when a master forwards commands to a replica via the replication connection, the replica doesn't
-  respond to each command. It just silently processes the commands and updates its state.
+Since the master doesn't receive a response for each command, it needs another way to keep track of whether a replica is "in sync". That's what ACKs are for.
 
-  Since the master doesn't receive a response for each command, it needs another way to keep track of whether a replica is "in sync".
-  That's what ACKs are for.
+ACK is short for "acknowledgement". Redis masters periodically ask replicas to send ACKs.
 
-  ACK is short for "acknowledgement". Redis masters periodically ask replicas to send ACKs.
+Each ACK contains an "offset", which is the number of bytes of commands processed by the replica.
 
-  Each ACK contains an "offset", which is the number of bytes of commands processed by the replica.
-
-  We'll learn about how this offset is calculated and used in later stages. In this stage, we'll focus on implementing the
-  mechanism through which a master asks for an ACK from a replica: the `REPLCONF GETACK` command.
-</details>
+We'll learn about how this offset is calculated and used in later stages. In this stage, we'll focus on implementing the mechanism through which a master asks for an ACK from a replica: the `REPLCONF GETACK` command.
 
 ### The `REPLCONF GETACK` command
 
-<details>
-  <summary>Click to expand/collapse</summary>
+When a master requires an ACK from a replica, it sends a `REPLCONF GETACK *` command to the replica. This is sent over the replication connection (i.e., the connection that remains after the replication handshake is complete).
 
-  When a master requires an ACK from a replica, it sends a `REPLCONF GETACK *` command to the replica. This is sent over
-  the replication connection (i.e. the connection that remains after the replication handshake is complete).
+When the replica receives this command, it responds with a `REPLCONF ACK <offset>` response. The offset is the number of bytes of commands processed by the replica. It starts at 0 and is incremented for every command processed by the replica.
 
-  When the replica receives this command, it responds with a `REPLCONF ACK <offset>` response. The offset is the
-  number of bytes of commands processed by the replica. It starts at 0 and is incremented for every command processed by the replica.
+In this stage, you'll implement support for receiving the `REPLCONF GETACK *` command and responding with `REPLCONF ACK 0`.
 
-  In this stage, you'll implement support for receiving the `REPLCONF GETACK *` command and responding with `REPLCONF ACK 0`.
+You can hardcode the offset to 0 for now. We'll implement proper offset tracking in the next stage.
 
-  You can hardcode the offset to 0 for now. We'll implement proper offset tracking in the next stage.
-
-  The exact command received by the replica will look something like this: `*3\r\n$8\r\nreplconf\r\n$6\r\ngetack\r\n$1\r\n*\r\n` (that's
-  `["replconf", "getack", "*"]` encoded as a [RESP Array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays)).
-</details>
+The exact command received by the replica will look something like this: `*3\r\n$8\r\nreplconf\r\n$6\r\ngetack\r\n$1\r\n*\r\n`, that's `["replconf", "getack", "*"]` encoded as a [RESP array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays).
 
 ### Tests
 
@@ -48,12 +34,11 @@ The tester will execute your program like this:
 
 Just like in the previous stages, your replica should complete the handshake with the master and receive an empty RDB file.
 
-The master will then send `REPLCONF GETACK *` to your replica. It'll expect to receive `REPLCONF ACK 0` as a reply.
+The master will then send `REPLCONF GETACK *` to your replica. It will expect to receive `REPLCONF ACK 0` as a reply.
 
 ### Notes
 
-- The response should be encoded as a [RESP Array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays), like
-  this: `*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n`.
-- We'll implement proper offset tracking in the next stage, for now you can hardcode the offset to 0.
+- The response should be encoded as a [RESP array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays), like this: `*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n`.
+- We'll implement proper offset tracking in the next stage. For now, you can hardcode the offset to `0`.
 - After the master-replica handshake is complete, a replica should **only** send responses to `REPLCONF GETACK` commands. All
   other propagated commands (like `PING`, `SET` etc.) should be read and processed, but a response should not be sent back to the master.

--- a/stage_descriptions/replication-14-xv6.md
+++ b/stage_descriptions/replication-14-xv6.md
@@ -2,27 +2,27 @@ In this stage, you'll implement support for responding to the `REPLCONF GETACK` 
 
 ### ACKs
 
-Unlike regular commands, when a master forwards commands to a replica via the replication connection, the replica doesn't respond to each command. It just silently processes the commands and updates its state.
+Normally, a replica processes propagated commands silently. However, the master needs a way to verify that a replica is "in sync" and hasn't fallen behind. This is done using ACKs (acknowledgements).
 
-Since the master doesn't receive a response for each command, it needs another way to keep track of whether a replica is "in sync". That's what ACKs are for.
-
-ACK is short for "acknowledgement". Redis masters periodically ask replicas to send ACKs.
-
-Each ACK contains an "offset", which is the number of bytes of commands processed by the replica.
-
-We'll learn about how this offset is calculated and used in later stages. In this stage, we'll focus on implementing the mechanism through which a master asks for an ACK from a replica: the `REPLCONF GETACK` command.
+Redis masters periodically ask replicas to send ACKs to check how much of the replication stream they’ve processed.
 
 ### The `REPLCONF GETACK` command
 
-When a master requires an ACK from a replica, it sends a `REPLCONF GETACK *` command to the replica. This is sent over the replication connection (i.e., the connection that remains after the replication handshake is complete).
+When the master wants an update, it sends the command:
 
-When the replica receives this command, it responds with a `REPLCONF ACK <offset>` response. The offset is the number of bytes of commands processed by the replica. It starts at 0 and is incremented for every command processed by the replica.
+```bash
+REPLCONF GETACK *
+```
 
-In this stage, you'll implement support for receiving the `REPLCONF GETACK *` command and responding with `REPLCONF ACK 0`.
+The exact command received by the replica will look something like this: `*3\r\n$8\r\nreplconf\r\n$6\r\ngetack\r\n$1\r\n*\r\n`. That's `["replconf", "getack", "*"]` encoded as a [RESP array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays).
 
-You can hardcode the offset to 0 for now. We'll implement proper offset tracking in the next stage.
+The replica receives this command over the replication connection (i.e., the connection used for the replication handshake) and responds with:
 
-The exact command received by the replica will look something like this: `*3\r\n$8\r\nreplconf\r\n$6\r\ngetack\r\n$1\r\n*\r\n`, that's `["replconf", "getack", "*"]` encoded as a [RESP array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays).
+```bash
+REPLCONF ACK <offset>
+```
+
+The offset is the number of bytes of commands processed by the replica. For this stage, you can hardcode the offset to `0`. We'll learn how to track offsets and update them in later stages.
 
 ### Tests
 
@@ -34,11 +34,10 @@ The tester will execute your program like this:
 
 Just like in the previous stages, your replica should complete the handshake with the master and receive an empty RDB file.
 
-The master will then send `REPLCONF GETACK *` to your replica. It will expect to receive `REPLCONF ACK 0` as a reply.
+The tester will then send `REPLCONF GETACK *` to your replica. 
+
+It will expect to receive `REPLCONF ACK 0` encoded as a RESP array (`*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n`).
 
 ### Notes
 
-- The response should be encoded as a [RESP array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays), like this: `*3\r\n$8\r\nREPLCONF\r\n$3\r\nACK\r\n$1\r\n0\r\n`.
-- We'll implement proper offset tracking in the next stage. For now, you can hardcode the offset to `0`.
-- After the master-replica handshake is complete, a replica should **only** send responses to `REPLCONF GETACK` commands. All
-  other propagated commands (like `PING`, `SET` etc.) should be read and processed, but a response should not be sent back to the master.
+- After the master-replica handshake is complete, a replica should **only** send responses to `REPLCONF GETACK` commands. All other propagated commands (like `PING`, `SET`, etc.) should be read and processed, but a response should not be sent back to the master.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines replication stage docs to clearly describe REPLCONF GETACK/ACK flow, RESP formats, and tester behavior.
> 
> - **Docs (replication stage `replication-14-xv6.md`)**:
>   - Clarify ACKs purpose and how masters request them; remove collapsible details for brevity.
>   - Add explicit `REPLCONF GETACK *` and `REPLCONF ACK <offset>` examples and RESP array encoding for both request and expected response.
>   - Specify that the tester (not master) sends `REPLCONF GETACK *` and expects `REPLCONF ACK 0`.
>   - Consolidate notes; emphasize replicas only reply to GETACK after handshake; minor wording/punctuation cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7c3e83c5ebc692f45bc2fd91b00c2c9a82238cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->