### PR TITLE
Revise "WAIT with no commands #tu8" (stage 59)

### DIFF
--- a/stage_descriptions/replication-17-tu8.md
+++ b/stage_descriptions/replication-17-tu8.md
@@ -17,7 +17,7 @@ $ redis-cli WAIT 9 500
 (integer) 7
 ```
 
-In the example above, `7` replicas are connected. No matter how many replicas the client asks for, the master will reply with the number of connected replicas (`7`) once the timeout has passed.
+In the example above, `7` replicas are connected. No matter how many replicas the client asks for, the master will reply with the number of connected replicas (`7`).
 
 For this stage, you can ignore both arguments (`<numreplicas> <timeout>`) and simply return the number of connected replicas.
 


### PR DESCRIPTION
Updated instructions for the WAIT implementation stage to clarify handling of connected replicas and response behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the WAIT stage to return the number of connected replicas when no writes have occurred, regardless of provided arguments.
> 
> - **Docs**: Update `stage_descriptions/replication-17-tu8.md` to define `WAIT` behavior with connected replicas when replication offset is `0`.
>   - Master returns the count of connected replicas, ignoring `<numreplicas> <timeout>`.
>   - Add examples demonstrating responses independent of requested replica count.
>   - Update test flow and notes to reflect returning connected replica count and non-hardcoded values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af71a991b2ad303c2bfef6299f91d33ace80bd58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->