### PR TITLE
Revise "WAIT with multiple commands #na2" (stage 60)

### DIFF
--- a/stage_descriptions/replication-18-na2.md
+++ b/stage_descriptions/replication-18-na2.md
@@ -1,9 +1,37 @@
-**🚧 We're still working on instructions for this stage**. You can find notes on how the tester works below.
+In this stage, you’ll extend your `WAIT` implementation to handle the case where replicas are connected and have received write commands.
 
-<!--
-In this stage you will implement WAIT, when some replicas are connected to Master, and there have been commands propagated from master to replica. So the offset is NOT 0. In this case, the Master has to figure out how many replicas the previous write command has been successfully propagated to.
-(The replicas will finish the sync handshake with Master, and process any commands you send it, but they WON'T send periodic ACKs, so you need to basically send a REPLCONF GETACK to get their current offset. )
--->
+### `WAIT` with propagated commands
+
+In previous stages, we handled the cases where:
+- No replicas were connected, and the master could safely return `0`.
+- Replicas were connected, but hadn't received any write commands.
+
+Now, we’ll handle the case where write commands have been sent to replicas. Since replication offsets are no longer `0`, the master needs to check which replicas have successfully processed the latest write command before replying.
+
+To do this, the master must explicitly send a `REPLCONF GETACK *` command to replicas. Each replica will reply with its current offset (`REPLCONF ACK <offset>`). Using these offsets, the master can determine how many replicas have processed the last write.
+
+The `WAIT` command should complete when either:
+
+- The required number of replicas has acknowledged the last write, or
+- The timeout expires.
+
+Either way, the master returns the number of replicas that acknowledged the command.
+
+Here’s an example:
+
+```bash
+$ redis-cli SET foo 123
+"OK"
+
+$ redis-cli WAIT 1 500
+(integer) 1   # returned as soon as 1 replica confirmed the write
+
+$ redis-cli SET bar 456
+"OK"
+
+$ redis-cli WAIT 2 500
+(integer) 2   # returned when 2 replicas confirmed within 500ms
+```
 
 ### Tests
 

--- a/stage_descriptions/replication-18-na2.md
+++ b/stage_descriptions/replication-18-na2.md
@@ -8,30 +8,14 @@ In previous stages, we handled the cases where:
 
 Now, we’ll handle the case where write commands have been sent to replicas. Since replication offsets are no longer `0`, the master needs to check which replicas have successfully processed the latest write command before replying.
 
-To do this, the master must explicitly send a `REPLCONF GETACK *` command to replicas. Each replica will reply with its current offset (`REPLCONF ACK <offset>`). Using these offsets, the master can determine how many replicas have processed the last write.
+To do this, the master must send `REPLCONF GETACK *` to replicas to check if there are pending write commands since the last `WAIT`. Each replica will reply with its current offset (`REPLCONF ACK <offset>`).
 
 The `WAIT` command should complete when either:
 
-- The required number of replicas has acknowledged the last write, or
+- The required number of replicas has acknowledged the last write command, or
 - The timeout expires.
 
-Either way, the master returns the number of replicas that acknowledged the command.
-
-Here’s an example:
-
-```bash
-$ redis-cli SET foo 123
-"OK"
-
-$ redis-cli WAIT 1 500
-(integer) 1   # returned as soon as 1 replica confirmed the write
-
-$ redis-cli SET bar 456
-"OK"
-
-$ redis-cli WAIT 2 500
-(integer) 2   # returned when 2 replicas confirmed within 500ms
-```
+Either way, the master returns the number of replicas that acknowledged the command as a [RESP integer](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers)
 
 ### Tests
 
@@ -41,21 +25,19 @@ The tester will execute your program as a master like this:
 ./your_program.sh
 ```
 
-It'll then start **multiple** replicas that connect to your server. Each will complete the handshake and expect to receive an empty RDB file.
+It will then start **multiple** replicas that connect to your server. Each will complete the handshake and expect to receive an empty RDB file.
 
-The tester will then connect to your master as a Redis client (not one of the replicas) and send multiple write commands interleaved
-with `WAIT` commands:
+Next, the tester will connect to your master as a client and send multiple write commands interleaved with `WAIT` commands:
 
 ```bash
 $ redis-cli SET foo 123
-$ redis-cli WAIT 1 500 # (must wait until either 1 replica has processed previous commands or 500ms have passed)
+$ redis-cli WAIT 1 500    # (must wait until either 1 replica has processed previous commands or 500ms have passed)
 
 $ redis-cli SET bar 456
-$ redis-cli WAIT 2 500 # (must wait until either 2 replicas have processed previous commands or 500ms have passed)
+$ redis-cli WAIT 2 500    # (must wait until either 2 replicas have processed previous commands or 500ms have passed)
 ```
 
 ### Notes
 
-- The `WAIT` command should return when either (a) the specified number of replicas have acknowledged the command, or (b) the timeout expires.
 - The `WAIT` command should always return the number of replicas that have acknowledged the command, even if the timeout expires.
 - The returned number of replicas might be lesser than or greater than the expected number of replicas specified in the `WAIT` command.

--- a/stage_descriptions/replication-18-na2.md
+++ b/stage_descriptions/replication-18-na2.md
@@ -15,7 +15,7 @@ The `WAIT` command should complete when either:
 - The required number of replicas has acknowledged the last write command, or
 - The timeout expires.
 
-Either way, the master returns the number of replicas that acknowledged the command as a [RESP integer](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers).
+Either way, the master should return the number of replicas that acknowledged the command as a [RESP integer](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers).
 
 ### Tests
 
@@ -39,5 +39,4 @@ $ redis-cli WAIT 2 500    # (must wait until either 2 replicas have processed pr
 
 ### Notes
 
-- The `WAIT` command should always return the number of replicas that have acknowledged the command, even if the timeout expires.
-- The returned number of replicas might be lesser than or greater than the expected number of replicas specified in the `WAIT` command.
+- The returned number of replicas might be less than or greater than the expected number of replicas specified in the `WAIT` command.

--- a/stage_descriptions/replication-18-na2.md
+++ b/stage_descriptions/replication-18-na2.md
@@ -15,7 +15,7 @@ The `WAIT` command should complete when either:
 - The required number of replicas has acknowledged the last write command, or
 - The timeout expires.
 
-Either way, the master returns the number of replicas that acknowledged the command as a [RESP integer](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers)
+Either way, the master returns the number of replicas that acknowledged the command as a [RESP integer](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers).
 
 ### Tests
 

--- a/stage_descriptions/replication-18-na2.md
+++ b/stage_descriptions/replication-18-na2.md
@@ -8,7 +8,7 @@ In previous stages, we handled the cases where:
 
 Now, we’ll handle the case where write commands have been sent to replicas. Since replication offsets are no longer `0`, the master needs to check which replicas have successfully processed the latest write command before replying.
 
-To do this, the master must send `REPLCONF GETACK *` to replicas to check if there are pending write commands since the last `WAIT`. Each replica will reply with its current offset (`REPLCONF ACK <offset>`).
+To do this, the master must send `REPLCONF GETACK *` to replicas if there are pending write commands since the last `WAIT`. Each replica will reply with its current offset (`REPLCONF ACK <offset>`).
 
 The `WAIT` command should complete when either:
 


### PR DESCRIPTION
Expanded instructions for the WAIT implementation to handle cases with connected replicas and write commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand the replication stage doc to cover WAIT after propagated writes, requiring `REPLCONF GETACK *` and counting ACKed offsets; update tests and notes.
> 
> - **Docs**: update `stage_descriptions/replication-18-na2.md`
>   - **WAIT with propagated commands**: explain sending `REPLCONF GETACK *` to replicas and handling `REPLCONF ACK <offset>`; complete when required replicas acknowledge the last write or timeout; return count as RESP integer.
>   - **Tests**: refine client workflow description and example `WAIT` calls (interleaved with writes, spacing/wording tweaks).
>   - **Notes**: clarify that the returned replica count may be less or greater than requested; minor phrasing cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9a0552a7fc484b1942a4d03f9823df167e9939e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->