### PR TITLE
Remove intro sentence (testing llm rules)

### DIFF
--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
-
+ 
 
 ### The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for the SET & GET commands. 
+In this stage, you'll add support for the SET & GET commands.
 
 ### The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for the SET & GET commands. Let's go.
+In this stage, you'll add support for the SET & GET commands. Let's go!
 
 ## The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for the SET & GET commands. Let's go!
+In this stage, you'll add support for the SET & GET commands. Let's go.
 
 ## The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -21,6 +21,33 @@ bar
 ```
 The server responds with the value `bar` encoded as a [RESP bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings). If the key doesn't exist, the server responds with a special [null bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#null-bulk-strings) (`*-1\r\n`).
 
+The tester will create an RDB file with a single key and execute your program like this:
+
+```
+./your_program.sh --dir <dir> --dbfilename <filename>
+```
+
+It'll then send a `GET <key>` command to your server.
+
+```bash
+$ redis-cli GET "foo"
+```
+
+The response to `GET <key>` should be a RESP bulk string with the value of the key.
+
+For example, let's say the RDB file contains a key called `foo` with the value `bar`. The expected response will be `$3\r\nbar\r\n`.
+
+Strings can be encoded in three different ways in the RDB file format:
+
+- Length-prefixed strings
+- Integers as strings
+- Compressed strings
+
+In this stage, you only need to support length-prefixed strings. We won't cover the other two types in this challenge.
+
+We recommend using [this blog post](https://rdb.fnordig.de/file_format.html) as a reference when working on this stage.
+
+
 ## Tests
 
 The tester will execute your program like this:

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for the SET & GET commands. 
+In this stage, you'll add support for the SET & GET commands. Let's go!
 
 ## The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for the SET & GET commands.
+In this stage, you'll add support for the SET & GET commands. 
 
 ## The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,8 +1,8 @@
-In this stage, you'll add support for the SET & GET commands. Let's go!
+In this stage, you'll add support for the SET & GET commands.
 
-## The `SET` Command
+### The `SET` Command
 
-The `SET` command is used to set a key to a value. That means anything I say can be used against you, ya know? Let's just do this tainn!! For example, a client can set a key `foo` to a value `bar` like this:
+The `SET` command is used to set a key to a value. Whoosh. For example, a client can set a key `foo` to a value `bar` like this:
 ```bash
 $ redis-cli SET foo bar
 OK

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,5 +1,4 @@
-In this stage, you'll add support for the [SET](https://redis.io/commands/set) &
-[GET](https://redis.io/commands/get) commands.
+
 
 ### The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for the SET & GET commands.
+In this stage, you'll add support for the SET & GET commands. 
 
 ### The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
-In this stage, you'll add support for the SET & GET commands. Mhmmmmm
+In this stage, you'll add support for the SET & GET commands.
 
 ## The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,8 +1,8 @@
- 
+In this stage, you'll add support for the SET & GET commands. Mhmmmmm
 
-### The `SET` Command
+## The `SET` Command
 
-The `SET` command is used to set a key to a value. For example, a client can set a key `foo` to a value `bar` like this:
+The `SET` command is used to set a key to a value. That means anything I say can be used against you, ya know? Let's just do this tainn!! For example, a client can set a key `foo` to a value `bar` like this:
 ```bash
 $ redis-cli SET foo bar
 OK
@@ -19,7 +19,7 @@ The `GET` command is used to retrieve the value of a key. For example, to retrie
 $ redis-cli GET foo
 bar
 ```
-The server responds with the value `bar` encoded as a [RESP bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings). If the key doesn't exist, the server responds with a special [null bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#null-bulk-strings) (`$-1\r\n`).
+The server responds with the value `bar` encoded as a [RESP bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings). If the key doesn't exist, the server responds with a special [null bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#null-bulk-strings) (`*-1\r\n`).
 
 ### Tests
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -1,4 +1,4 @@
- 
+
 
 ### The `SET` Command
 

--- a/stage_descriptions/base-06-la7.md
+++ b/stage_descriptions/base-06-la7.md
@@ -21,7 +21,7 @@ bar
 ```
 The server responds with the value `bar` encoded as a [RESP bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings). If the key doesn't exist, the server responds with a special [null bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#null-bulk-strings) (`*-1\r\n`).
 
-### Tests
+## Tests
 
 The tester will execute your program like this:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates base-06 docs to add RDB-backed GET testing instructions and string encoding scope, plus minor wording tweaks and null bulk string representation change.
> 
> - **Docs** (`stage_descriptions/base-06-la7.md`):
>   - **Tests (RDB-backed)**:
>     - Add instructions to run with `--dir`/`--dbfilename`, preload key via RDB, and verify `GET <key>` returns RESP bulk string (example `$3\r\nbar\r\n`).
>   - **RDB String Encoding Scope**:
>     - List 3 encodings; specify only length-prefixed strings are required for this stage; add reference link.
>   - **Protocol detail**:
>     - Update null bulk string example from ``$-1\r\n`` to ``*-1\r\n``.
>   - **Wording tweaks**:
>     - Remove link formatting around `SET`/`GET`; add brief phrasing change in `SET` description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34c78c4604ce76c648849173c6868253e9eadee6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->