### PR TITLE
Use `gradle distTar` in Kotlin compile.sh

### DIFF
--- a/compiled_starters/kotlin/.codecrafters/compile.sh
+++ b/compiled_starters/kotlin/.codecrafters/compile.sh
@@ -8,7 +8,7 @@
 
 set -e # Exit on failure
 
-gradle build
+gradle distTar
 cd /tmp/codecrafters-build-redis-kotlin/distributions
 rm -rf app
 tar -xvf app.tar

--- a/compiled_starters/kotlin/your_program.sh
+++ b/compiled_starters/kotlin/your_program.sh
@@ -14,7 +14,7 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
-  gradle build
+  gradle distTar
   cd /tmp/codecrafters-build-redis-kotlin/distributions
   rm -rf app
   tar -xvf app.tar

--- a/solutions/kotlin/01-jm1/code/.codecrafters/compile.sh
+++ b/solutions/kotlin/01-jm1/code/.codecrafters/compile.sh
@@ -8,7 +8,7 @@
 
 set -e # Exit on failure
 
-gradle build
+gradle distTar
 cd /tmp/codecrafters-build-redis-kotlin/distributions
 rm -rf app
 tar -xvf app.tar

--- a/solutions/kotlin/01-jm1/code/your_program.sh
+++ b/solutions/kotlin/01-jm1/code/your_program.sh
@@ -14,7 +14,7 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
-  gradle build
+  gradle distTar
   cd /tmp/codecrafters-build-redis-kotlin/distributions
   rm -rf app
   tar -xvf app.tar

--- a/starter_templates/kotlin/code/.codecrafters/compile.sh
+++ b/starter_templates/kotlin/code/.codecrafters/compile.sh
@@ -8,7 +8,7 @@
 
 set -e # Exit on failure
 
-gradle build
+gradle distTar
 cd /tmp/codecrafters-build-redis-kotlin/distributions
 rm -rf app
 tar -xvf app.tar


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces `gradle build` with `gradle distTar` across Kotlin compile/run scripts to produce and extract the distribution tarball.
> 
> - **Kotlin build/run scripts**:
>   - Switch `gradle build` -> `gradle distTar` in:
>     - `compiled_starters/kotlin/.codecrafters/compile.sh`
>     - `compiled_starters/kotlin/your_program.sh`
>     - `solutions/kotlin/01-jm1/code/.codecrafters/compile.sh`
>     - `solutions/kotlin/01-jm1/code/your_program.sh`
>     - `starter_templates/kotlin/code/.codecrafters/compile.sh`
>   - Existing steps to extract `app.tar` and run the app remain the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0473084941d6cb2b962df9dbebc980a7765fc1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->