### PR TITLE
Revise "Default AOF options #uj3"

### DIFF
--- a/stage_descriptions/aof-01-uj3.md
+++ b/stage_descriptions/aof-01-uj3.md
@@ -2,9 +2,9 @@ In this stage, you'll set up default values for AOF-related configuration option
 
 ### AOF Persistence in Redis
 
-AOF (Append Only File) is one of Redis's persistence strategies. When enabled, the server logs every write command to a file. If the server restarts or crashes, it replays the file to rebuild its in-memory state.
+Redis keeps all its data in memory, which makes it fast but vulnerable. If the server crashes, everything is gone. AOF (Append Only File) is one way to solve this. When enabled, the server logs every write command to a file, and on restart, it replays the file to rebuild its state.
 
-AOF behavior is controlled by several configuration options. In this stage, you'll set up their default values so they can be retrieved with `CONFIG GET`. You don't need to implement any actual persistence logic yet.
+The AOF behavior is controlled by several configuration options. For this stage, you'll set up their default values so they can be retrieved with `CONFIG GET`. You don't need to implement any actual persistence logic yet.
 
 Here are the options and their defaults:
 

--- a/stage_descriptions/aof-01-uj3.md
+++ b/stage_descriptions/aof-01-uj3.md
@@ -1,18 +1,20 @@
-In this stage, you'll implement the default values for AOF-related options.
+In this stage, you'll set up default values for AOF-related configuration options.
 
-### AOF Persistence Options
+### AOF Persistence in Redis
 
-AOF (Append Only File) persistence records every write operation received by the server in a log file. When AOF is enabled, Redis appends each modifying command to the end of the file. On restart, the server replays the file to rebuild the in-memory state. This is useful for recovery if the server restarts or crashes.
+AOF (Append Only File) is one of Redis's persistence strategies. When enabled, the server logs every write command to a file. If the server restarts or crashes, it replays the file to rebuild its in-memory state.
 
-- The `dir` option - Controls the path where the data files for Redis will be persisted. Its default value is the directory under which Redis is started.
+AOF behavior is controlled by several configuration options. In this stage, you'll set up their default values so they can be retrieved with `CONFIG GET`. You don't need to implement any actual persistence logic yet.
 
-- The `appendonly` option - Controls whether AOF persistence is enabled or disabled. Its default value is `no`.
+Here are the options and their defaults:
 
-- The `appenddirname` option - Specifies the directory name under `dir` where the append-only file and the manifest file are stored. Its default value is `appendonlydir`.
-
-- The `appendfilename` option - Sets the name of the AOF file. Its default value is `appendonly.aof`.
-
-- The `appendfsync` option - Controls when the commands sent to Redis are written to the append-only file. Its default value is `everysec`.
+| Option | Purpose | Default |
+|---|---|---|
+| `dir` | The base directory where Redis stores its data files | Current working directory at startup |
+| `appendonly` | Controls whether AOF persistence is enabled or disabled | `no` |
+| `appenddirname` | The subdirectory under `dir` where AOF and manifest files are stored | `appendonlydir` |
+| `appendfilename` | The name of the append-only file that records write operations | `appendonly.aof` |
+| `appendfsync` | How often buffered writes are flushed to the AOF file on disk | `everysec` |
 
 ### Tests
 
@@ -22,24 +24,42 @@ The tester will execute your program like this:
 $ ./your_program.sh
 ```
 
-It will then send the following commands:
+It will then query each option using `CONFIG GET`:
 
 ```bash
 $ redis-cli CONFIG GET dir
+1) "dir"
+2) "/path/to/current/directory"
+
 $ redis-cli CONFIG GET appendonly
+1) "appendonly"
+2) "no"
+
 $ redis-cli CONFIG GET appenddirname
+1) "appenddirname"
+2) "appendonlydir"
+
 $ redis-cli CONFIG GET appendfilename
+1) "appendfilename"
+2) "appendonly.aof"
+
 $ redis-cli CONFIG GET appendfsync
+1) "appendfsync"
+2) "everysec"
 ```
 
-Your server must respond to each `CONFIG GET` command with a RESP array containing two elements: the parameter name and its default value, each encoded as a [RESP Bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings).
-
-For example, the expected response for `CONFIG GET appendonly` is:
-
+Each response is a RESP array with two [bulk strings](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the option name and its value. For example, `CONFIG GET appendonly` should return:
+ 
 ```
 *2\r\n$10\r\nappendonly\r\n$2\r\nno\r\n
 ```
 
+The tester will verify that:
+
+- Each `CONFIG GET` returns a two-element RESP array
+- The option name and default value are correct for each option
+
 ### Notes
 
-- You don't need to set up anything related to AOF persistence at this stage. You only need to set up the default values of `dir`, `appendonly`, `appenddirname`, `appendfilename`, and `appendfsync`.
+- You don't need to implement any AOF persistence logic in this stage. Just store and return the default values.
+- If you've already implemented `CONFIG GET` for other options in a previous challenge, you may just need to add these new keys to your existing configuration.


### PR DESCRIPTION
Updated descriptions and default values for AOF-related options in Redis configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the stage instructions; no runtime or persistence logic is modified.
> 
> **Overview**
> Updates the `aof-01-uj3` stage description to better explain AOF persistence and clarify that only default config values must be returned via `CONFIG GET` (no persistence implementation).
> 
> Reformats the required options (`dir`, `appendonly`, `appenddirname`, `appendfilename`, `appendfsync`) into a table, expands the expected `CONFIG GET` examples/RESP response requirements, and adds clearer tester verification notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa8f66574f6b2b37749812752d4651d395e4e7cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->