### PR TITLE
Revise "AOF options from flags #vd9"

### DIFF
--- a/stage_descriptions/aof-02-vd9.md
+++ b/stage_descriptions/aof-02-vd9.md
@@ -2,7 +2,7 @@ In this stage, you'll accept AOF configuration values from command-line flags.
 
 ### Overriding Defaults With Flags
 
-In the previous stage, you set up default values for AOF options. Now you'll allow those defaults to be overridden by command-line flags: `--dir`, `--appendonly`, `--appenddirname`, `--appendfilename`, and `--appendfsync`.
+In previous stages, you set up default values for AOF options. Now you'll allow those defaults to be overridden by command-line flags: `--dir`, `--appendonly`, `--appenddirname`, `--appendfilename`, and `--appendfsync`.
 
 When a flag is provided, its value takes precedence over the default. When a flag is omitted, the default from the previous stage still applies.
 

--- a/stage_descriptions/aof-02-vd9.md
+++ b/stage_descriptions/aof-02-vd9.md
@@ -4,7 +4,7 @@ In this stage, you'll accept AOF configuration values from command-line flags.
 
 In previous stages, you set up default values for AOF options. Now you'll allow those defaults to be overridden by command-line flags: `--dir`, `--appendonly`, `--appenddirname`, `--appendfilename`, and `--appendfsync`.
 
-When a flag is provided, its value takes precedence over the default. When a flag is omitted, the default from the previous stage still applies.
+When a flag is provided, its value takes precedence over the default. When a flag is omitted, the default from previous stages still applies.
 
 ### Tests
 

--- a/stage_descriptions/aof-02-vd9.md
+++ b/stage_descriptions/aof-02-vd9.md
@@ -1,18 +1,20 @@
-In this stage, you'll accept the values of AOF configuration options from the command line flags.
+In this stage, you'll accept AOF configuration values from command-line flags.
 
-### AOF Persistence Flags
+### Overriding Defaults With Flags
 
-When the `--dir`, `--appendonly`, `--appenddirname`, `--appendfilename`, and `--appendfsync` flags are provided, these override the default value of the corresponding options.
+In the previous stage, you set up default values for AOF options. Now you'll allow those defaults to be overridden by command-line flags: `--dir`, `--appendonly`, `--appenddirname`, `--appendfilename`, and `--appendfsync`.
+
+When a flag is provided, its value takes precedence over the default. When a flag is omitted, the default from the previous stage still applies.
 
 ### Tests
 
-The tester will execute your program like this:
+The tester will execute your program with some or all of the flags:
 
 ```bash
 $ ./your_program.sh --dir <dir> --appendonly yes --appenddirname <append_dir_name> --appendfilename <append_file_name> --appendfsync everysec
 ```
 
-It will then send the following commands:
+It will then query each option using `CONFIG GET`:
 
 ```bash
 $ redis-cli CONFIG GET dir
@@ -22,14 +24,19 @@ $ redis-cli CONFIG GET appendfilename
 $ redis-cli CONFIG GET appendfsync
 ```
 
-Your server must respond to each `CONFIG GET` command with a RESP array containing two elements: the parameter name and its value, each encoded as a [RESP Bulk string](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings). The value must be the one passed via the corresponding command-line flag (or the default if the flag was omitted).
-
-If the program is started with `--appendonly yes --appenddirname myaofdir --appendfilename myfile.aof`, then the expected response for `CONFIG GET appendonly` is:
+Each response should return the value passed via the corresponding flag. For example, if the program is started with `--appendonly yes`, then `CONFIG GET appendonly` should return:
 
 ```
-*2\r\n$9\r\nappendonly\r\n$3\r\nyes\r\n
+*2\r\n$10\r\nappendonly\r\n$3\r\nyes\r\n
 ```
+
+The tester will verify that:
+
+- Each `CONFIG GET` returns the value from the corresponding command-line flag
+- Options without flags still return their default values
 
 ### Notes
 
-- You do not need to implement any AOF persistence logic in this stage. You only need to parse the flags and return the values from `CONFIG GET`.
+- You don't need to implement any AOF persistence logic in this stage. Just parse the flags and return the values from `CONFIG GET`.
+- If you already parse command-line flags for other options (like `--port`), you can follow the same approach for these new flags.
+- You don't need to handle duplicate flags or any specific flag ordering. The tester will pass each flag at most once.


### PR DESCRIPTION
Updated descriptions for AOF configuration options and command-line flags. Clarified the behavior of flags and their precedence over default values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify precedence of AOF command-line flags and expected `CONFIG GET` responses; no runtime behavior changes.
> 
> **Overview**
> Updates the `aof-02-vd9` stage description to clarify that AOF option defaults can be *overridden* by the `--dir`, `--appendonly`, `--appenddirname`, `--appendfilename`, and `--appendfsync` flags, and that omitted flags should retain prior defaults.
> 
> Refines the testing section to describe how the tester queries each option via `CONFIG GET`, adds explicit verification criteria, and corrects the sample RESP output for `appendonly`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724a17027abef5cd2ba79507cf1039a538be0e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->