### PR TITLE
Refactor Dockerfile for .NET 10.0 build process

### DIFF
--- a/dockerfiles/dotnet-10.0.Dockerfile
+++ b/dockerfiles/dotnet-10.0.Dockerfile
@@ -9,12 +9,9 @@ WORKDIR /app
 # .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
 COPY --exclude=.git --exclude=README.md . /app
 
-# This saves nuget packages to ~/.nuget
-RUN dotnet build --configuration Release .
+RUN .codecrafters/compile.sh
 
 # This seems to cause a caching issue with the dotnet build command, where old contents are used
 # TODO: See if this needs to be brought back?
 # RUN rm -rf /app/obj
 # RUN rm -rf /app/bin
-
-RUN .codecrafters/compile.sh


### PR DESCRIPTION
- Removed the previous build command and adjusted the Dockerfile to use a custom compile script.
- Commented out potential cache-clearing commands for future consideration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Docker image build steps for .NET 10 by removing the explicit `dotnet build` layer, which can affect build caching and artifact generation. Low code risk but could impact CI/runtime if the custom compile script differs from the previous build behavior.
> 
> **Overview**
> Updates the .NET 10 Dockerfile to **drop the standalone `dotnet build` step** and rely solely on running `.codecrafters/compile.sh` during image build.
> 
> Also removes a duplicated compile invocation and leaves `obj`/`bin` cleanup commands commented out for potential cache troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a10d379197f22c543db5c529609b5f162de04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->