### PR TITLE
Revise "Create append-only directory #fm0"

### DIFF
--- a/stage_descriptions/aof-03-fm0.md
+++ b/stage_descriptions/aof-03-fm0.md
@@ -1,8 +1,18 @@
-In this stage, you'll add support for creating an append-only directory when append-only mode is enabled.
+In this stage, you'll create the append-only directory when AOF persistence is enabled.
 
-### The append-only directory
+### Creating the Append-Only Directory
 
-If the `--appendonly yes` flag has been specified, and the `appenddirname` does not exist inside the `dir` directory, Redis creates the directory.
+Now that your server can accept AOF configuration from command-line flags, it's time to start acting on them. When the server starts with `--appendonly yes`, it needs a directory to store its AOF files in. This directory lives inside the `dir` path and is named according to the `appenddirname` option.
+
+For example, if the server is started with:
+
+```bash
+$ ./your_program.sh --dir /tmp/redis-data --appendonly yes --appenddirname appendonlydir
+```
+
+It should create the directory `/tmp/redis-data/appendonlydir/` if it doesn't already exist.
+
+If `--appendonly` is not set to `yes`, the directory should not be created.
 
 ### Tests
 
@@ -12,10 +22,12 @@ The tester will execute your program like this:
 $ ./your_program.sh --dir <dir> --appendonly yes --appenddirname <append_dir_name> --appendfilename <append_file_name>
 ```
 
-It will then check whether the following directory has been created:
+The tester will verify that:
 
-- `<dir>/<append_dir_name>`
+- The directory `<dir>/<append_dir_name>` has been created
+- The directory exists before any client commands are sent (it should be created at startup)
 
 ### Notes
 
-- You don't have to create the contents inside the directory in this stage. We'll get to that in the later stages.
+- You don't need to create any files inside the directory yet. That comes in later stages.
+- If the directory already exists, your server should not return an error.


### PR DESCRIPTION
Updated the description for creating the append-only directory when AOF persistence is enabled, including command-line flag details and conditions for directory creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify expected startup behavior and test conditions; no runtime code changes.
> 
> **Overview**
> Clarifies the `aof-03-fm0` stage description to explicitly require creating `<dir>/<appenddirname>` *at startup* only when `--appendonly yes` is set, including a concrete CLI example.
> 
> Updates the test expectations and notes to state the directory must exist before any client commands, should not be created when AOF is disabled, and should not error if it already exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a72222e51e75a56bfd796ae0aa4b1f2f4585fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->