### PR TITLE
Revise "Create append-only file #dw4"

### DIFF
--- a/stage_descriptions/aof-04-dw4.md
+++ b/stage_descriptions/aof-04-dw4.md
@@ -1,10 +1,18 @@
-In this stage, you'll add support for creating the append-only file when append-only mode is enabled.
+In this stage, you'll create the append-only file when AOF persistence is enabled.
 
-### The append-only file
+### Creating the Append-Only File
 
-If the `--appendonly yes` flag has been specified, and the directory `appenddirname` does not exist inside the `dir` directory, Redis creates the directory. Inside that directory, Redis creates an empty file named `<appendfilename>.1.incr.aof`.
+In earlier stages, you created the append-only directory at startup. Now you'll also create an empty AOF file inside that directory.
 
-This file is the append-only file which Redis uses to store the command logs, which can be used later for restoring the key-value pairs.
+The file follows a specific naming convention: `<appendfilename>.1.incr.aof`. The `.1.incr` suffix indicates this is the first incremental AOF file. Redis uses incremental files to record commands as they come in, which it can replay later to restore state after a restart.
+
+For example, if the server is started with:
+
+```bash
+$ ./your_program.sh --dir /tmp/redis-data --appendonly yes --appenddirname appendonlydir --appendfilename appendonly.aof
+```
+
+It should create an empty file at `/tmp/redis-data/appendonlydir/appendonly.aof.1.incr.aof`.
 
 ### Tests
 
@@ -14,11 +22,12 @@ The tester will execute your program like this:
 $ ./your_program.sh --dir <dir> --appendonly yes --appenddirname <append_dir_name> --appendfilename <append_file_name>
 ```
 
-It will then check the following:
+The tester will verify that:
 
-- The directory `<dir>/<append_dir_name>` is created
-- An empty file `<dir>/<append_dir_name>/<append_file_name>.1.incr.aof` is created
+- The directory `<dir>/<append_dir_name>` exists
+- An empty file `<dir>/<append_dir_name>/<append_file_name>.1.incr.aof` has been created
 
 ### Notes
 
-- You don't need to create any files other than the append-only file in this stage. We'll get to creating other files in the later stages.
+- The file should be created at startup, not on the first write command.
+- You don't need to write any content to the file yet. That comes in later stages.

--- a/stage_descriptions/aof-04-dw4.md
+++ b/stage_descriptions/aof-04-dw4.md
@@ -22,10 +22,10 @@ The tester will execute your program like this:
 $ ./your_program.sh --dir <dir> --appendonly yes --appenddirname <append_dir_name> --appendfilename <append_file_name>
 ```
 
-The tester will verify that:
+The tester will then verify that:
 
 - The directory `<dir>/<append_dir_name>` exists
-- An empty file `<dir>/<append_dir_name>/<append_file_name>.1.incr.aof` has been created
+- An empty file `<dir>/<append_dir_name>/<append_file_name>.1.incr.aof` is created
 
 ### Notes
 

--- a/stage_descriptions/aof-04-dw4.md
+++ b/stage_descriptions/aof-04-dw4.md
@@ -2,7 +2,7 @@ In this stage, you'll create the append-only file when AOF persistence is enable
 
 ### Creating the Append-Only File
 
-In earlier stages, you created the append-only directory at startup. Now you'll also create an empty AOF file inside that directory.
+Along with the append-only directory, your server also needs to create an empty AOF file inside it at startup.
 
 The file follows a specific naming convention: `<appendfilename>.1.incr.aof`. The `.1.incr` suffix indicates this is the first incremental AOF file. Redis uses incremental files to record commands as they come in, which it can replay later to restore state after a restart.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies expected filesystem side effects and test assertions; no runtime or security impact.
> 
> **Overview**
> Updates the `aof-04-dw4` stage description to explicitly require creating an empty incremental AOF file (`<appendfilename>.1.incr.aof`) *at startup* when AOF is enabled, including an example path.
> 
> Clarifies the tester expectations by tightening the wording around directory existence and the specific AOF filename to be created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6082882260638a271c042cd3da9361370211fcd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->