### PR TITLE
Revise "Write a single command #dc8"

### DIFF
--- a/stage_descriptions/aof-06-dc8.md
+++ b/stage_descriptions/aof-06-dc8.md
@@ -1,8 +1,8 @@
-In this stage, you'll write commands to the append-only file after they're executed.
+In this stage, you'll write a single modifying command to the append-only file.
 
 ### Writing to the Append-Only File
 
-So far, you've been creating the AOF directory, file, and manifest at startup. Now you'll start using them. When `--appendonly yes` is set and your server processes a write command (like `SET`), it should append that command to the append-only file in [RESP](https://redis.io/docs/latest/develop/reference/protocol-spec/) format.
+So far, you've created the AOF directory, file, and manifest at startup. Now you'll start using them. When `--appendonly yes` is set and your server processes a write command (like `SET`), it should append that command to the append-only file in [RESP](https://redis.io/docs/latest/develop/reference/protocol-spec/) format.
 
 Your server should read the manifest to find the name of the AOF file to write to. The manifest's `type i` entry tells you which file is the active incremental file.
 
@@ -18,7 +18,7 @@ It should append the following to the AOF file:
 *3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n100\r\n
 ```
 
-This is the same RESP encoding your server already uses for communication. The command is stored exactly as it was received, so it can be replayed on restart to rebuild state.
+This is the same RESP encoding your server already uses for communication. The command is stored exactly as it was received, so it can be replayed on restart to rebuild the state.
 
 ### The `appendfsync always` Option
 
@@ -46,7 +46,7 @@ $ redis-cli SET <key> <value>
 The tester will verify that:
 
 - The command is appended to the AOF file named in the manifest (not the default `<appendfilename>.1.incr.aof`)
-- The command is written in valid RESP format
+- The command is written in a valid RESP format
 - The write is flushed to disk before the client receives a response
 
 ### Notes

--- a/stage_descriptions/aof-06-dc8.md
+++ b/stage_descriptions/aof-06-dc8.md
@@ -1,17 +1,35 @@
-In this stage, you'll add support for writing a single modifying command to the append-only file after it is processed.
+In this stage, you'll write commands to the append-only file after they're executed.
 
-### Writing to the append-only file
+### Writing to the Append-Only File
 
-When `--appendonly yes` is set, the manifest at `dir/appenddirname/appendfilename.manifest` lists the append-only file (type `i`) where commands must be stored. After Redis executes a write command (for example `SET`), it appends that command to the append-only file in [RESP](https://redis.io/docs/latest/develop/reference/protocol-spec/) form.
+So far, you've been creating the AOF directory, file, and manifest at startup. Now you'll start using them. When `--appendonly yes` is set and your server processes a write command (like `SET`), it should append that command to the append-only file in [RESP](https://redis.io/docs/latest/develop/reference/protocol-spec/) format.
 
-When `appendfsync` is `always`, Redis flushes the command to disk before sending the reply to the client.
+Your server should read the manifest to find the name of the AOF file to write to. The manifest's `type i` entry tells you which file is the active incremental file.
+
+For example, if your server receives:
+
+```bash
+$ redis-cli SET foo 100
+```
+
+It should append the following to the AOF file:
+
+```
+*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n100\r\n
+```
+
+This is the same RESP encoding your server already uses for communication. The command is stored exactly as it was received, so it can be replayed on restart to rebuild state.
+
+### The `appendfsync always` Option
+
+When `appendfsync` is set to `always`, the server must flush the write to disk before sending a response to the client. This guarantees that no acknowledged write can be lost, even if the server crashes immediately after responding.
 
 ### Tests
 
-The tester will create the following under `dir/appenddirname`:
+The tester will create the following under `<dir>/<append_dir_name>`:
 
-- A manifest whose type `i` entry names a file `<random_file_name>.1.incr.aof`
-- The append-only file mentioned in the manifest file: `<random_file_name>.1.incr.aof`.
+- A manifest whose `type i` entry names a file `<random_file_name>.1.incr.aof`
+- The corresponding empty AOF file: `<random_file_name>.1.incr.aof`
 
 The tester will execute your program like this:
 
@@ -19,23 +37,20 @@ The tester will execute your program like this:
 $ ./your_program.sh --dir <dir> --appendonly yes --appenddirname <append_dir_name> --appendfilename <append_file_name> --appendfsync always
 ```
 
-It will then send a single command, for example:
+It will then send a single write command:
 
 ```bash
 $ redis-cli SET <key> <value>
 ```
 
-The tester will expect the command to be written to the append-only file that was mentioned in the manifest file.
+The tester will verify that:
 
-For example, if the command is `SET foo 100`, the content that should be written to the append-only file is:
-
-```
-*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n100\r\n
-```
+- The command is appended to the AOF file named in the manifest (not the default `<appendfilename>.1.incr.aof`)
+- The command is written in valid RESP format
+- The write is flushed to disk before the client receives a response
 
 ### Notes
 
-- You must read the manifest to determine which file to open for writes. The tester uses a non-default filename to ensure you follow the manifest and not only `<appendfilename>.1.incr.aof`.
-
-- You don't need to implement the behavior of `--appendfsync everysec`.
-
+- You must read the manifest to determine which file to write to. The tester intentionally uses a non-default filename to make sure your server follows the manifest.
+- You don't need to handle `--appendfsync everysec` in this stage. Only `always` is tested.
+- The RESP encoding of the command is the same format you're already using for client-server communication. You're just writing it to a file instead of a socket.


### PR DESCRIPTION
Updated the stage description to clarify the process of writing commands to the append-only file and the handling of the manifest file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that clarify expected behavior and test assertions without affecting runtime code.
> 
> **Overview**
> Clarifies the stage instructions for writing a single modifying command to the AOF by explicitly requiring **reading the manifest’s `type i` entry** to choose the active `.incr.aof` file and appending the command in **RESP** format.
> 
> Expands the description of `appendfsync always` to require flushing to disk before replying, and updates the test section/notes to reflect the manifest-driven filename and durability expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed1cc330110d44cbd6d35f0ba41552c06d3bc684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->