### PR TITLE
Revise "Write multiple commands #fi1"

### DIFF
--- a/stage_descriptions/aof-07-fi1.md
+++ b/stage_descriptions/aof-07-fi1.md
@@ -2,7 +2,7 @@ In this stage, you'll extend AOF logging to handle multiple write commands.
 
 ### Appending Multiple Commands
 
-In earlier stages, you wrote a single command to the append-only file. Now you'll handle multiple commands in sequence. Each write command should be appended to the file in the order it was received, so the file builds up a complete log of all modifications. This applies to any command that modifies data (like `SET`, `DEL`, `INCR`, `LPUSH`, etc.), not just `SET`.
+Each write command should be appended to the file in the order it was received, so the file builds up a complete log of all modifications. This applies to any command that modifies data (like `SET`, `DEL`, `INCR`, `LPUSH`, etc.), not just `SET`.
 
 For example, if the server receives:
 
@@ -29,6 +29,8 @@ bar\r\n
 $3\r\n
 200\r\n
 ```
+
+*(The `\r\n` sequences above are shown on separate lines for readability. In the actual file, each command is a continuous sequence of bytes with `\r\n` as delimiters.)*
 
 Each command is appended immediately after the previous one with no separators between them. On replay, the RESP framing (`*3\r\n...`) is enough to tell where one command ends and the next begins.
 

--- a/stage_descriptions/aof-07-fi1.md
+++ b/stage_descriptions/aof-07-fi1.md
@@ -45,7 +45,12 @@ The tester will execute your program like this:
 $ ./your_program.sh --dir <dir> --appendonly yes --appenddirname <append_dir_name> --appendfilename <append_file_name> --appendfsync always
 ```
 
-It will then send two write commands with different keys.
+It will then send two write commands with different keys:
+
+```bash
+$ redis-cli SET <key1> <value1>
+$ redis-cli SET <key2> <value2>
+```
 
 The tester will verify that:
 

--- a/stage_descriptions/aof-07-fi1.md
+++ b/stage_descriptions/aof-07-fi1.md
@@ -2,7 +2,7 @@ In this stage, you'll extend AOF logging to handle multiple write commands.
 
 ### Appending Multiple Commands
 
-Each write command should be appended to the file in the order it was received, so the file builds up a complete log of all modifications. This applies to any command that modifies data (like `SET`, `DEL`, `INCR`, `LPUSH`, etc.), not just `SET`.
+Each write command should be appended to the AOF file in the order it was received, so the file builds up a complete log of all modifications. This applies to any command that modifies data (like `SET`, `DEL`, `INCR`, `LPUSH`, etc.), not just `SET`.
 
 For example, if the server receives:
 

--- a/stage_descriptions/aof-07-fi1.md
+++ b/stage_descriptions/aof-07-fi1.md
@@ -1,45 +1,30 @@
-In this stage, you'll add support for writing multiple commands to the append-only file.
+In this stage, you'll extend AOF logging to handle multiple write commands.
 
-### Writing to the append-only file
+### Appending Multiple Commands
 
-When `--appendonly yes` is set, the manifest at `dir/appenddirname/appendfilename.manifest` lists the append-only file (type `i`) where commands must be stored.
+In earlier stages, you wrote a single command to the append-only file. Now you'll handle multiple commands in sequence. Each write command should be appended to the file in the order it was received, so the file builds up a complete log of all modifications. This applies to any command that modifies data (like `SET`, `DEL`, `INCR`, `LPUSH`, etc.), not just `SET`.
 
-After the server executes a write command, it appends that command to the append-only file in [RESP](https://redis.io/docs/latest/develop/reference/protocol-spec/) form. When several write commands are executed one after another, each should be appended so the file contains all of them, in order.
-
-If the following commands are sent to the server:
+For example, if the server receives:
 
 ```bash
 $ redis-cli SET foo 100
 $ redis-cli SET bar 200
 ```
 
-the append-only file contains both commands, in order, as RESP-encoded data—for example:
+The append-only file should contain both commands in order:
 
 ```
-*3\r\n
-$3\r\n
-SET\r\n
-$3\r\n
-foo\r\n
-$3\r\n
-100\r\n
-*3\r\n
-$3\r\n
-SET\r\n
-$3\r\n
-bar\r\n
-$3\r\n
-200\r\n
+*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n100\r\n*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n200\r\n
 ```
 
-If `appendfsync` is `always`, each command is written to the append-only file before sending the response back to the client.
+Each command is appended immediately after the previous one with no separators between them. On replay, the RESP framing (`*3\r\n...`) is enough to tell where one command ends and the next begins.
 
 ### Tests
 
-The tester will create the following under `dir/appenddirname`:
+The tester will create the following under `<dir>/<append_dir_name>`:
 
-- A manifest whose type `i` entry names a file `<random_file_name>.1.incr.aof`
-- The append-only file mentioned in the manifest file: `<random_file_name>.1.incr.aof`.
+- A manifest whose `type i` entry names a file `<random_file_name>.1.incr.aof`
+- The corresponding empty AOF file: `<random_file_name>.1.incr.aof`
 
 The tester will execute your program like this:
 
@@ -47,36 +32,16 @@ The tester will execute your program like this:
 $ ./your_program.sh --dir <dir> --appendonly yes --appenddirname <append_dir_name> --appendfilename <append_file_name> --appendfsync always
 ```
 
-It will then send two modifying commands in order. For example, it may send `SET <key1> <value1>` and then `SET <key2> <value2>` for two different keys. Both commands should appear in the append-only file, in the same order, as RESP-encoded commands.
+It will then send two write commands with different keys.
 
-For example, if the tester sent:
+The tester will verify that:
 
-```bash
-$ redis-cli SET foo 100
-$ redis-cli SET bar 200
-```
-
-The content of the append-only file should be:
-
-```
-*3\r\n
-$3\r\n
-SET\r\n
-$3\r\n
-foo\r\n
-$3\r\n
-100\r\n
-*3\r\n
-$3\r\n
-SET\r\n
-$3\r\n
-bar\r\n
-$3\r\n
-200\r\n
-```
+- Both commands appear in the append-only file in the order they were sent
+- Each command is encoded in a valid RESP format
+- The writes are flushed to disk before the client receives a response (since `appendfsync` is `always`)
 
 ### Notes
 
-- You must read the manifest to determine which file to open for writes. The tester uses a non-default filename to ensure you follow the manifest and not only `<appendfilename>.1.incr.aof`.
-
-- You don't need to implement the behavior of `--appendfsync everysec`.
+- If your implementation from earlier stages already appends (rather than overwrites), this stage may already pass without changes.
+- You must read the manifest to determine which file to write to. The tester uses a non-default filename.
+- You don't need to handle `--appendfsync everysec` in this stage.

--- a/stage_descriptions/aof-07-fi1.md
+++ b/stage_descriptions/aof-07-fi1.md
@@ -14,7 +14,20 @@ $ redis-cli SET bar 200
 The append-only file should contain both commands in order:
 
 ```
-*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\n100\r\n*3\r\n$3\r\nSET\r\n$3\r\nbar\r\n$3\r\n200\r\n
+*3\r\n
+$3\r\n
+SET\r\n
+$3\r\n
+foo\r\n
+$3\r\n
+100\r\n
+*3\r\n
+$3\r\n
+SET\r\n
+$3\r\n
+bar\r\n
+$3\r\n
+200\r\n
 ```
 
 Each command is appended immediately after the previous one with no separators between them. On replay, the RESP framing (`*3\r\n...`) is enough to tell where one command ends and the next begins.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update that clarifies expected AOF append semantics and test assertions; no runtime code changes.
> 
> **Overview**
> Updates the `aof-07-fi1` stage write-up to more explicitly require **appending multiple write commands** to the AOF in received order (and for all mutating commands, not just `SET`), and clarifies that RESP framing is sufficient to delimit back-to-back commands.
> 
> Rewords the test description to use parameterized keys, clarifies the manifest/AOF files created under `<dir>/<append_dir_name>`, and lists explicit tester checks including `appendfsync always` flush-before-response behavior and a note that earlier append-based implementations may already pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2baf049a25aec624d05616ca41b9ff28af823447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->