### PR TITLE
Revise "Replay a single command #xz2"

### DIFF
--- a/stage_descriptions/aof-09-xz2.md
+++ b/stage_descriptions/aof-09-xz2.md
@@ -1,16 +1,24 @@
-In this stage, you'll add support for restoring the database by replaying a single command from the append-only file.
+In this stage, you'll restore the state on startup by replaying commands from the append-only file.
 
-### Replaying the append-only file
+### Replaying the Append-Only File
 
-On startup with `--appendonly yes`, if the append-only directory is already present inside `dir`, Redis reads the manifest file at `dir/appenddirname/appendfilename.manifest`. It parses each line to find the file entry whose type is `i` (incremental). That entry gives the name of the append-only file in the same directory. Redis opens that file and parses it as a sequence of RESP-encoded commands, replaying each command in order as if the client had sent it. After replaying all the commands, the database is restored.
+In earlier stages, you wrote commands to the AOF file as they came in. Now you'll do the reverse: on startup, read those commands back and replay them to rebuild the database.
+
+When the server starts with `--appendonly yes` and the append-only directory already exists, it should:
+
+1. Read the manifest file at `<dir>/<append_dir_name>/<append_file_name>.manifest`
+2. Find the entry with `type i` (the incremental file)
+3. Open that file and parse the RESP-encoded commands inside it
+4. Execute each command as if a client had sent it
+
+After replaying, the database should be in the same state it was in when the commands were originally written. This is how Redis recovers data after a restart.
 
 ### Tests
 
-The tester will create a directory `<dir>/<appenddirname>`.
+The tester will create a directory `<dir>/<append_dir_name>` containing:
 
-Inside the directory, it'll create an append-only file `<random_file_name>.1.incr.aof` that will contain one RESP-encoded command, `SET <key> <value>`
-
-It will also create a manifest file `<appendfilename>.manifest`, which will contain the following line:
+- An AOF file `<random_file_name>.1.incr.aof` with a single RESP-encoded `SET` command
+- A manifest file `<append_file_name>.manifest` pointing to that AOF file:
 
 ```
 file <random_file_name>.1.incr.aof seq 1 type i
@@ -22,23 +30,18 @@ The tester will execute your program like this:
 $ ./your_program.sh --dir <dir> --appendonly yes --appenddirname <append_dir_name> --appendfilename <append_file_name>
 ```
 
-Your program should do the following:
-
-- Read the manifest file `<dir>/<appenddirname>/<appendfilename>.manifest`
-- Identify the `file` specified in the line inside the manifest, which is the append-only file.
-- Read the append-only file, which will contain one command to be replayed.
-- Replay the command as if it was sent by a client.
-
-The tester will then create a new client and send a `GET` command:
+After startup, the tester will send a `GET` command to verify the replayed data:
 
 ```bash
 $ redis-cli GET <key>
 ```
 
-The value returned should be the value specified in the append-only file.
+The tester will verify that:
+
+- The value returned by `GET` matches the value from the `SET` command in the AOF file
+- Your server read the AOF file named in the manifest, not a hardcoded filename
 
 ### Notes
 
-- You should not directly read the file `<dir>/<appenddirname>/<appendfilename>.1.incr.aof`. You should read and replay commands from the file which is specified in the `<appendfilename>.manifest`.
-
-- Redis always uses the format `file <appendfilename>.1.incr.aof seq 1 type i` in the manifest file. The tester will, however, use a different file name `file <random_file_name>.1.incr.aof seq 1 type i` to ensure that the file mentioned in the manifest is read, and not the one complying with the default format.
+- You must read the manifest to find which file to replay. The tester intentionally uses a non-default filename (`<random_file_name>.1.incr.aof` instead of `<append_file_name>.1.incr.aof`) to make sure your server follows the manifest.
+- The AOF file contains the same RESP format you already parse from client connections. You can reuse your existing RESP parser here.


### PR DESCRIPTION
Updated the stage description for restoring the database by replaying commands from the append-only file, clarified testing steps and requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies AOF replay behavior and tester expectations; no runtime code paths are modified.
> 
> **Overview**
> Updates the `aof-09-xz2` stage description to focus on *startup database recovery* by replaying RESP commands from the AOF file referenced by the manifest.
> 
> Clarifies the expected steps (read manifest, select `type i` entry, open that file, execute commands) and tightens the test requirements to explicitly ensure implementations follow the manifest’s filename rather than a hardcoded default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c76566a5ba09ba99534e87f6a75185d14b1a54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->