### PR TITLE
Update AOF file command description for clarity

### DIFF
--- a/stage_descriptions/aof-07-fi1.md
+++ b/stage_descriptions/aof-07-fi1.md
@@ -11,7 +11,7 @@ $ redis-cli SET foo 100
 $ redis-cli SET bar 200
 ```
 
-The append-only file should contain both commands in order:
+The AOF file should contain both commands in order:
 
 ```
 *3\r\n
@@ -30,7 +30,7 @@ $3\r\n
 200\r\n
 ```
 
-*(The `\r\n` sequences above are shown on separate lines for readability. In the actual file, each command is a continuous sequence of bytes with `\r\n` as delimiters.)*
+*(The `\r\n` sequences above are shown on separate lines for readability. In the actual file, each command is a continuous sequence of bytes.)*
 
 Each command is appended immediately after the previous one with no separators between them. On replay, the RESP framing (`*3\r\n...`) is enough to tell where one command ends and the next begins.
 


### PR DESCRIPTION
Clarified the description of the AOF file format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies wording around AOF command framing without altering any code paths.
> 
> **Overview**
> Clarifies the stage docs for AOF multi-command appends by rewording the example expectation ("AOF file" vs "append-only file") and tightening the note about how `\r\n` is presented in the rendered example versus the actual on-disk byte stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f331664fc9dd80c837c77eca449abf6b0f6ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->