### PR TITLE
Fix formatting and clarity in AOF documentation

### DIFF
--- a/stage_descriptions/aof-08-ep6.md
+++ b/stage_descriptions/aof-08-ep6.md
@@ -4,7 +4,7 @@ In this stage, you'll ensure that only write commands are logged to the append-o
 
 Commands that don't modify data, like `PING`, `GET`, and `ECHO`, should never be written to an AOF file since they don't change any state.
 
-If the server receives a mix of read and write commands, only the write commands should appear in the AOF file, in the order they were received.
+If the server receives a mix of read and write commands, only the write commands should appear in the AOF file in the order they were received.
 
 For example, if a client sends:
 
@@ -16,7 +16,7 @@ $ redis-cli ECHO hello
 $ redis-cli SET bar 2
 ```
 
-The append-only file should contain only the two `SET` commands:
+The AOF file should contain only the two `SET` commands:
 
 ```
 *3\r\n
@@ -35,7 +35,7 @@ $1\r\n
 2\r\n
 ```
 
-*(The `\r\n` sequences above are shown on separate lines for readability. In the actual file, each command is a continuous sequence of bytes with `\r\n` as delimiters.)*
+*(The `\r\n` sequences above are shown on separate lines for readability. In the actual file, each command is a continuous sequence of bytes.)*
 
 No trace of `GET`, `PING`, or `ECHO` should appear in the file.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording tweaks; no code paths or behavior change, so risk is minimal.
> 
> **Overview**
> Tightens wording in `stage_descriptions/aof-08-ep6.md` to clarify that **only write commands** should be persisted to the AOF *in received order*.
> 
> Renames “append-only file” references to “AOF file” in the example description and simplifies the note about `\r\n` formatting to avoid implying additional delimiter details beyond the continuous byte sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe6fd4eadacfc46da405e00fd92703c33f4ede4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->