### PR TITLE
Add solutions and hints for Go stage 3 (Respond to multiple PINGs)

### DIFF
--- a/solutions/go/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/go/03-wy1/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+go build -o /tmp/codecrafters-build-redis-go app/*.go

--- a/solutions/go/03-wy1/code/.codecrafters/run.sh
+++ b/solutions/go/03-wy1/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec /tmp/codecrafters-build-redis-go "$@"

--- a/solutions/go/03-wy1/code/.gitattributes
+++ b/solutions/go/03-wy1/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/go/03-wy1/code/README.md
+++ b/solutions/go/03-wy1/code/README.md
@@ -1,0 +1,33 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for Go solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in `app/main.go`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `go (1.26)` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `app/main.go`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/go/03-wy1/code/app/main.go
+++ b/solutions/go/03-wy1/code/app/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+func main() {
+	l, err := net.Listen("tcp", "0.0.0.0:6379")
+	if err != nil {
+		fmt.Println("Failed to bind to port 6379")
+		os.Exit(1)
+	}
+	conn, err := l.Accept()
+	if err != nil {
+		fmt.Println("Error accepting connection: ", err.Error())
+		os.Exit(1)
+	}
+	buf := make([]byte, 1024)
+	for {
+		_, err := conn.Read(buf)
+		if err != nil {
+			break
+		}
+		conn.Write([]byte("+PONG\r\n"))
+	}
+}

--- a/solutions/go/03-wy1/code/codecrafters.yml
+++ b/solutions/go/03-wy1/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Go version used to run your code
+# on Codecrafters.
+#
+# Available versions: go-1.26
+buildpack: go-1.26

--- a/solutions/go/03-wy1/code/go.mod
+++ b/solutions/go/03-wy1/code/go.mod
@@ -1,0 +1,3 @@
+module github.com/codecrafters-io/redis-starter-go
+
+go 1.26.0

--- a/solutions/go/03-wy1/code/your_program.sh
+++ b/solutions/go/03-wy1/code/your_program.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  go build -o /tmp/codecrafters-build-redis-go app/*.go
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec /tmp/codecrafters-build-redis-go "$@"

--- a/solutions/go/03-wy1/config.yml
+++ b/solutions/go/03-wy1/config.yml
@@ -1,0 +1,29 @@
+hints:
+  - title_markdown: "How do I read data from a client connection?"
+    body_markdown: |-
+      Use the [`Read()`](https://pkg.go.dev/net#Conn.Read) method on the client's connection to read data into a byte slice:
+
+      ```go
+      buf := make([]byte, 1024)
+      n, err := conn.Read(buf)
+      ```
+
+      - `buf` is a [byte slice](https://go.dev/blog/slices-intro#slices) that acts as a buffer to hold the incoming data.
+      - `Read()` returns the number of bytes read and an error. The error will be non-nil when the client closes the connection.
+
+  - title_markdown: "How do I handle multiple commands?"
+    body_markdown: |-
+      Wrap your `Read()` and `Write()` calls in a loop. Break out of the loop when the client disconnects (i.e., when `Read()` returns an error):
+
+      ```go
+      buf := make([]byte, 1024)
+      for {
+          _, err := conn.Read(buf)
+          if err != nil {
+              break
+          }
+          conn.Write([]byte("+PONG\r\n"))
+      }
+      ```
+
+      This loop will keep reading commands and responding with `+PONG\r\n` until the client closes the connection.

--- a/solutions/go/03-wy1/diff/app/main.go.diff
+++ b/solutions/go/03-wy1/diff/app/main.go.diff
@@ -1,0 +1,34 @@
+@@ -1,25 +1,28 @@
+ package main
+
+ import (
+ 	"fmt"
+ 	"net"
+ 	"os"
+ )
+
+-// Ensures gofmt doesn't remove the "net" and "os" imports in stage 1 (feel free to remove this!)
+-var _ = net.Listen
+-var _ = os.Exit
+-
+ func main() {
+ 	l, err := net.Listen("tcp", "0.0.0.0:6379")
+ 	if err != nil {
+ 		fmt.Println("Failed to bind to port 6379")
+ 		os.Exit(1)
+ 	}
+ 	conn, err := l.Accept()
+ 	if err != nil {
+ 		fmt.Println("Error accepting connection: ", err.Error())
+ 		os.Exit(1)
+ 	}
+-	conn.Write([]byte("+PONG\r\n"))
++	buf := make([]byte, 1024)
++	for {
++		_, err := conn.Read(buf)
++		if err != nil {
++			break
++		}
++		conn.Write([]byte("+PONG\r\n"))
++	}
+ }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Adds the Go solution and hints for **stage 3 (`03-wy1`): Respond to multiple PINGs**.

### Solution

The solution extends stage 2 by wrapping the connection handling in a read loop. Instead of writing a single `+PONG\r\n` response and exiting, it continuously reads from the connection and responds with `+PONG\r\n` for each command received, breaking when the client disconnects (i.e., `Read()` returns an error).

### Hints

Two hints are provided in `config.yml`, following the same structure and tone as the Go stage 2 hints and the Python stage 3 hints:

1. **"How do I read data from a client connection?"** — explains `conn.Read()` with a byte slice buffer
2. **"How do I handle multiple commands?"** — shows the read/write loop pattern with error-based break

### Files added

- `solutions/go/03-wy1/code/` — full solution code (copied from stage 2, with read loop added)
- `solutions/go/03-wy1/config.yml` — hints for this stage
- `solutions/go/03-wy1/diff/app/main.go.diff` — auto-generated diff by `course-sdk compile`

### Testing

All three Go stages pass with `course-sdk test go`:

- Stage 1 (Bind to a port): passed
- Stage 2 (Respond to PING): passed
- Stage 3 (Respond to multiple PINGs): passed

[course_sdk_test_output.log](https://cursor.com/agents/bc-41cbf813-355a-42a1-be6e-035722edc320/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcourse_sdk_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41cbf813-355a-42a1-be6e-035722edc320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41cbf813-355a-42a1-be6e-035722edc320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

