### PR TITLE
Add solutions and hints for Java stage 3 (Respond to multiple PINGs)

### DIFF
--- a/solutions/java/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/java/03-wy1/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+mvn -q -B package -Ddir=/tmp/codecrafters-build-redis-java

--- a/solutions/java/03-wy1/code/.codecrafters/run.sh
+++ b/solutions/java/03-wy1/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec java --enable-preview -jar /tmp/codecrafters-build-redis-java/codecrafters-redis.jar "$@"

--- a/solutions/java/03-wy1/code/.gitattributes
+++ b/solutions/java/03-wy1/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/java/03-wy1/code/.gitignore
+++ b/solutions/java/03-wy1/code/.gitignore
@@ -1,0 +1,3 @@
+*.jar
+target/
+.idea/

--- a/solutions/java/03-wy1/code/README.md
+++ b/solutions/java/03-wy1/code/README.md
@@ -1,0 +1,34 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for Java solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in `src/main/java/Main.java`.
+Study and uncomment the relevant code, and push your changes to pass the first
+stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `mvn` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `src/main/java/Main.java`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/java/03-wy1/code/codecrafters.yml
+++ b/solutions/java/03-wy1/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Java version used to run your code
+# on Codecrafters.
+#
+# Available versions: java-25
+buildpack: java-25

--- a/solutions/java/03-wy1/code/pom.xml
+++ b/solutions/java/03-wy1/code/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.codecrafters</groupId>
+    <artifactId>codecrafters-redis</artifactId>
+    <version>1.0</version>
+
+    <properties>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>25</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>--enable-preview</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <finalName>codecrafters-redis</finalName> <!-- Please do not change this final artifact name-->
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <!-- This is the main class of your program which will be executed-->
+                            <mainClass>Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <outputDirectory>${dir}</outputDirectory>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/solutions/java/03-wy1/code/src/main/java/Main.java
+++ b/solutions/java/03-wy1/code/src/main/java/Main.java
@@ -1,0 +1,36 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class Main {
+  public static void main(String[] args){
+       ServerSocket serverSocket = null;
+       Socket clientSocket = null;
+       int port = 6379;
+       try {
+         serverSocket = new ServerSocket(port);
+         // Since the tester restarts your program quite often, setting SO_REUSEADDR
+         // ensures that we don't run into 'Address already in use' errors
+         serverSocket.setReuseAddress(true);
+         // Wait for connection from client.
+         clientSocket = serverSocket.accept();
+         InputStream inputStream = clientSocket.getInputStream();
+         byte[] buffer = new byte[1024];
+         int bytesRead;
+         while ((bytesRead = inputStream.read(buffer)) != -1) {
+           clientSocket.getOutputStream().write("+PONG\r\n".getBytes());
+         }
+       } catch (IOException e) {
+         System.out.println("IOException: " + e.getMessage());
+       } finally {
+         try {
+           if (clientSocket != null) {
+             clientSocket.close();
+           }
+         } catch (IOException e) {
+           System.out.println("IOException: " + e.getMessage());
+         }
+       }
+  }
+}

--- a/solutions/java/03-wy1/code/your_program.sh
+++ b/solutions/java/03-wy1/code/your_program.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  mvn -q -B package -Ddir=/tmp/codecrafters-build-redis-java
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec java --enable-preview -jar /tmp/codecrafters-build-redis-java/codecrafters-redis.jar "$@"

--- a/solutions/java/03-wy1/config.yml
+++ b/solutions/java/03-wy1/config.yml
@@ -1,0 +1,28 @@
+hints:
+  - title_markdown: "How do I read data from a client connection?"
+    body_markdown: |-
+      Use [`getInputStream()`](https://docs.oracle.com/javase/8/docs/api/java/net/Socket.html#getInputStream--) and [`read()`](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#read-byte:A-) to read data from the client:
+
+      ```java
+      InputStream inputStream = clientSocket.getInputStream();
+      byte[] buffer = new byte[1024];
+      int bytesRead = inputStream.read(buffer);
+      ```
+
+      - The `read()` method reads up to 1024 bytes into the buffer.
+      - It returns `-1` when the client has closed the connection.
+
+  - title_markdown: "How do I handle multiple commands?"
+    body_markdown: |-
+      Wrap your `read()` and `write()` calls in a loop. Break out of the loop when the client disconnects (i.e., when `read()` returns `-1`):
+
+      ```java
+      InputStream inputStream = clientSocket.getInputStream();
+      byte[] buffer = new byte[1024];
+      int bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        clientSocket.getOutputStream().write("+PONG\r\n".getBytes());
+      }
+      ```
+
+      This loop will keep reading commands and responding with `+PONG\r\n` until the client closes the connection.

--- a/solutions/java/03-wy1/diff/src/main/java/Main.java.diff
+++ b/solutions/java/03-wy1/diff/src/main/java/Main.java.diff
@@ -1,0 +1,38 @@
+@@ -1,30 +1,36 @@
+ import java.io.IOException;
++import java.io.InputStream;
+ import java.net.ServerSocket;
+ import java.net.Socket;
+
+ public class Main {
+   public static void main(String[] args){
+        ServerSocket serverSocket = null;
+        Socket clientSocket = null;
+        int port = 6379;
+        try {
+          serverSocket = new ServerSocket(port);
+          // Since the tester restarts your program quite often, setting SO_REUSEADDR
+          // ensures that we don't run into 'Address already in use' errors
+          serverSocket.setReuseAddress(true);
+          // Wait for connection from client.
+          clientSocket = serverSocket.accept();
+-         clientSocket.getOutputStream().write("+PONG\r\n".getBytes());
++         InputStream inputStream = clientSocket.getInputStream();
++         byte[] buffer = new byte[1024];
++         int bytesRead;
++         while ((bytesRead = inputStream.read(buffer)) != -1) {
++           clientSocket.getOutputStream().write("+PONG\r\n".getBytes());
++         }
+        } catch (IOException e) {
+          System.out.println("IOException: " + e.getMessage());
+        } finally {
+          try {
+            if (clientSocket != null) {
+              clientSocket.close();
+            }
+          } catch (IOException e) {
+            System.out.println("IOException: " + e.getMessage());
+          }
+        }
+   }
+ }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds the solution and hints for Java base stage 3 ("Respond to multiple PINGs").

## Changes

### Solution (`solutions/java/03-wy1/code/src/main/java/Main.java`)
- Adds a read loop using `InputStream.read()` that continuously reads commands from the client connection
- Responds with `+PONG\r\n` for each command received
- Breaks out of the loop when the client disconnects (`read()` returns `-1`)
- Incremental change from stage 2: replaces single `write()` with a `while` loop around `read()`/`write()`

### Hints (`solutions/java/03-wy1/config.yml`)
Two hints following the same structure and tone as the Python reference and Java stage 2 hints:
1. **"How do I read data from a client connection?"** - Explains `getInputStream()` and `read()` with a code example
2. **"How do I handle multiple commands?"** - Shows the while loop pattern with `read()` returning `-1` as the exit condition

## Testing
All stages pass with `course-sdk test java`:
- Starter code test: passed
- Stage 1 (Bind to a port): passed
- Stage 2 (Respond to PING): passed
- Stage 3 (Respond to multiple PINGs): passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4547c52-3a6b-4a6b-910a-84773da32991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4547c52-3a6b-4a6b-910a-84773da32991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

