### PR TITLE
Add solutions and hints for Clojure stage 3 (Respond to multiple PINGs)

### DIFF
--- a/solutions/clojure/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/clojure/03-wy1/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+clj -T:build

--- a/solutions/clojure/03-wy1/code/.codecrafters/run.sh
+++ b/solutions/clojure/03-wy1/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec java -jar /tmp/codecrafters-build-redis-clojure/target.jar "$@"

--- a/solutions/clojure/03-wy1/code/.gitattributes
+++ b/solutions/clojure/03-wy1/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/clojure/03-wy1/code/.gitignore
+++ b/solutions/clojure/03-wy1/code/.gitignore
@@ -1,0 +1,15 @@
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/lib/
+/classes/
+/target/
+/checkouts/
+.lein-deps-sum
+.lein-repl-history
+.lein-plugins/
+.lein-failures
+.nrepl-port
+.cpcache/
+deps/

--- a/solutions/clojure/03-wy1/code/README.md
+++ b/solutions/clojure/03-wy1/code/README.md
@@ -1,0 +1,33 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for Clojure solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in `src/redis/core.clj`. Study
+and uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `clj` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `src/redis/core.clj`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/clojure/03-wy1/code/build.clj
+++ b/solutions/clojure/03-wy1/code/build.clj
@@ -1,0 +1,22 @@
+(ns build
+  (:gen-class)
+  (:require [clojure.tools.build.api :as b]))
+
+(def lib 'io.codecrafters.redis)
+(def class-dir "/tmp/codecrafters-build-redis-clojure/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def uber-file "/tmp/codecrafters-build-redis-clojure/target.jar")
+
+(defn clean [_]
+  (b/delete {:path "/tmp/codecrafters-build-redis-clojure"}))
+
+(defn uber [_]
+  (clean nil)
+  (b/copy-dir {:src-dirs ["src"] :target-dir class-dir})
+  (b/compile-clj {:basis basis
+                  :ns-compile '[redis.core]
+                  :class-dir class-dir})
+  (b/uber {:class-dir class-dir
+           :uber-file uber-file
+           :basis basis
+           :main 'redis.core}))

--- a/solutions/clojure/03-wy1/code/codecrafters.yml
+++ b/solutions/clojure/03-wy1/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Clojure version used to run your code
+# on Codecrafters.
+#
+# Available versions: clojure-1.12.0
+buildpack: clojure-1.12.0

--- a/solutions/clojure/03-wy1/code/deps.edn
+++ b/solutions/clojure/03-wy1/code/deps.edn
@@ -1,0 +1,16 @@
+{
+  :paths ["src"]
+
+  :deps {
+    org.clojure/clojure {:mvn/version "1.12.0"}
+    org.clojure/tools.cli {:mvn/version "1.1.230"}
+    aleph/aleph {:mvn/version "0.8.3"}
+  }
+
+  :aliases {
+    :build {
+      :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.9"}}
+      :exec-fn build/uber
+    }
+  }
+}

--- a/solutions/clojure/03-wy1/code/src/redis/core.clj
+++ b/solutions/clojure/03-wy1/code/src/redis/core.clj
@@ -1,0 +1,35 @@
+(ns redis.core
+  (:gen-class))
+
+(require '[clojure.java.io :as io])
+(import '[java.net ServerSocket])
+
+(defn send-message
+  "Send the given string message out over the given socket"
+  [socket msg]
+  (let [writer (io/writer socket)]
+    (.write writer msg)
+    (.flush writer)))
+
+(defn handler
+  [& args]
+  "+PONG\r\n")
+
+(defn serve [port handler]
+  (with-open [server-sock (ServerSocket. port)]
+    (. server-sock (setReuseAddress true))
+
+    (with-open [sock (.accept server-sock)]
+      (let [in (.getInputStream sock)
+            buf (byte-array 1024)]
+        (loop []
+          (let [n (.read in buf)]
+            (when (pos? n)
+              (send-message sock (handler))
+              (recur))))))))
+
+(defn -main
+  "I don't do a whole lot ... yet."
+  [& args]
+  (serve 6379 handler)
+  )

--- a/solutions/clojure/03-wy1/code/src/redis/core.clj
+++ b/solutions/clojure/03-wy1/code/src/redis/core.clj
@@ -4,11 +4,6 @@
 (require '[clojure.java.io :as io])
 (import '[java.net ServerSocket])
 
-(defn receive-message
-  "Read a line of textual data from the given socket"
-  [socket]
-  (.readLine (io/reader socket)))
-
 (defn send-message
   "Send the given string message out over the given socket"
   [socket msg]

--- a/solutions/clojure/03-wy1/code/src/redis/core.clj
+++ b/solutions/clojure/03-wy1/code/src/redis/core.clj
@@ -4,6 +4,11 @@
 (require '[clojure.java.io :as io])
 (import '[java.net ServerSocket])
 
+(defn receive-message
+  "Read a line of textual data from the given socket"
+  [socket]
+  (.readLine (io/reader socket)))
+
 (defn send-message
   "Send the given string message out over the given socket"
   [socket msg]
@@ -11,22 +16,24 @@
     (.write writer msg)
     (.flush writer)))
 
+(defn serve [port handler]
+  (with-open [server-sock (ServerSocket. port)]
+    ;; Since the tester restarts your program quite often, setting SO_REUSEADDR
+    ;; ensures that we don't run into 'Address already in use' errors
+    (. server-sock (setReuseAddress true))
+
+   (with-open [sock (.accept server-sock)]
+    (let [in (.getInputStream sock)
+          buf (byte-array 1024)]
+      (loop []
+        (let [n (.read in buf)]
+          (when (pos? n)
+            (send-message sock (handler))
+            (recur))))))))
+
 (defn handler
   [& args]
   "+PONG\r\n")
-
-(defn serve [port handler]
-  (with-open [server-sock (ServerSocket. port)]
-    (. server-sock (setReuseAddress true))
-
-    (with-open [sock (.accept server-sock)]
-      (let [in (.getInputStream sock)
-            buf (byte-array 1024)]
-        (loop []
-          (let [n (.read in buf)]
-            (when (pos? n)
-              (send-message sock (handler))
-              (recur))))))))
 
 (defn -main
   "I don't do a whole lot ... yet."

--- a/solutions/clojure/03-wy1/code/your_program.sh
+++ b/solutions/clojure/03-wy1/code/your_program.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  clj -T:build
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec java -jar /tmp/codecrafters-build-redis-clojure/target.jar "$@"

--- a/solutions/clojure/03-wy1/config.yml
+++ b/solutions/clojure/03-wy1/config.yml
@@ -1,0 +1,29 @@
+hints:
+  - title_markdown: "How do I read data from a client connection?"
+    body_markdown: |-
+      Use the [`getInputStream()`](https://docs.oracle.com/javase/8/docs/api/java/net/Socket.html#getInputStream--) method on the client socket and read into a byte array:
+
+      ```clojure
+      (let [in (.getInputStream sock)
+            buf (byte-array 1024)]
+        (.read in buf))
+      ```
+
+      - The `1024` argument specifies the size of the buffer to read into.
+      - `.read` returns `-1` when the client has closed the connection, or the number of bytes read otherwise.
+
+  - title_markdown: "How do I handle multiple commands?"
+    body_markdown: |-
+      Use a `loop`/`recur` to continuously read from the input stream and respond. Break out of the loop when the client disconnects (i.e., when `.read` returns `-1` or `0`):
+
+      ```clojure
+      (let [in (.getInputStream sock)
+            buf (byte-array 1024)]
+        (loop []
+          (let [n (.read in buf)]
+            (when (pos? n)
+              (send-message sock "+PONG\r\n")
+              (recur)))))
+      ```
+
+      This loop will keep reading commands and responding with `+PONG\r\n` until the client closes the connection.

--- a/solutions/clojure/03-wy1/diff/src/redis/core.clj.diff
+++ b/solutions/clojure/03-wy1/diff/src/redis/core.clj.diff
@@ -1,15 +1,15 @@
-@@ -1,38 +1,35 @@
+@@ -1,38 +1,42 @@
  (ns redis.core
    (:gen-class))
 
  (require '[clojure.java.io :as io])
  (import '[java.net ServerSocket])
 
--(defn receive-message
--  "Read a line of textual data from the given socket"
--  [socket]
--  (.readLine (io/reader socket)))
--
+ (defn receive-message
+   "Read a line of textual data from the given socket"
+   [socket]
+   (.readLine (io/reader socket)))
+
  (defn send-message
    "Send the given string message out over the given socket"
    [socket msg]
@@ -17,32 +17,27 @@
      (.write writer msg)
      (.flush writer)))
 
-+(defn handler
-+  [& args]
-+  "+PONG\r\n")
-+
  (defn serve [port handler]
    (with-open [server-sock (ServerSocket. port)]
--    ;; Since the tester restarts your program quite often, setting SO_REUSEADDR
--    ;; ensures that we don't run into 'Address already in use' errors
+     ;; Since the tester restarts your program quite often, setting SO_REUSEADDR
+     ;; ensures that we don't run into 'Address already in use' errors
      (. server-sock (setReuseAddress true))
 
--   (with-open [sock (.accept server-sock)]
+    (with-open [sock (.accept server-sock)]
 -    (let [msg-in (receive-message sock)
 -          msg-out (handler msg-in)]
 -      (send-message sock msg-out)))))
--
--(defn handler
--  [& args]
--  "+PONG\r\n")
-+    (with-open [sock (.accept server-sock)]
-+      (let [in (.getInputStream sock)
-+            buf (byte-array 1024)]
-+        (loop []
-+          (let [n (.read in buf)]
-+            (when (pos? n)
-+              (send-message sock (handler))
-+              (recur))))))))
++    (let [in (.getInputStream sock)
++          buf (byte-array 1024)]
++      (loop []
++        (let [n (.read in buf)]
++          (when (pos? n)
++            (send-message sock (handler))
++            (recur))))))))
+
+ (defn handler
+   [& args]
+   "+PONG\r\n")
 
  (defn -main
    "I don't do a whole lot ... yet."

--- a/solutions/clojure/03-wy1/diff/src/redis/core.clj.diff
+++ b/solutions/clojure/03-wy1/diff/src/redis/core.clj.diff
@@ -1,0 +1,51 @@
+@@ -1,38 +1,35 @@
+ (ns redis.core
+   (:gen-class))
+
+ (require '[clojure.java.io :as io])
+ (import '[java.net ServerSocket])
+
+-(defn receive-message
+-  "Read a line of textual data from the given socket"
+-  [socket]
+-  (.readLine (io/reader socket)))
+-
+ (defn send-message
+   "Send the given string message out over the given socket"
+   [socket msg]
+   (let [writer (io/writer socket)]
+     (.write writer msg)
+     (.flush writer)))
+
++(defn handler
++  [& args]
++  "+PONG\r\n")
++
+ (defn serve [port handler]
+   (with-open [server-sock (ServerSocket. port)]
+-    ;; Since the tester restarts your program quite often, setting SO_REUSEADDR
+-    ;; ensures that we don't run into 'Address already in use' errors
+     (. server-sock (setReuseAddress true))
+
+-   (with-open [sock (.accept server-sock)]
+-    (let [msg-in (receive-message sock)
+-          msg-out (handler msg-in)]
+-      (send-message sock msg-out)))))
+-
+-(defn handler
+-  [& args]
+-  "+PONG\r\n")
++    (with-open [sock (.accept server-sock)]
++      (let [in (.getInputStream sock)
++            buf (byte-array 1024)]
++        (loop []
++          (let [n (.read in buf)]
++            (when (pos? n)
++              (send-message sock (handler))
++              (recur))))))))
+
+ (defn -main
+   "I don't do a whole lot ... yet."
+   [& args]
+   (serve 6379 handler)
+   )

--- a/solutions/clojure/03-wy1/diff/src/redis/core.clj.diff
+++ b/solutions/clojure/03-wy1/diff/src/redis/core.clj.diff
@@ -1,15 +1,15 @@
-@@ -1,38 +1,42 @@
+@@ -1,38 +1,37 @@
  (ns redis.core
    (:gen-class))
 
  (require '[clojure.java.io :as io])
  (import '[java.net ServerSocket])
 
- (defn receive-message
-   "Read a line of textual data from the given socket"
-   [socket]
-   (.readLine (io/reader socket)))
-
+-(defn receive-message
+-  "Read a line of textual data from the given socket"
+-  [socket]
+-  (.readLine (io/reader socket)))
+-
  (defn send-message
    "Send the given string message out over the given socket"
    [socket msg]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the Clojure solution and hints for stage 3 (`wy1` — "Respond to multiple PINGs").

## Changes

**Solution** (`solutions/clojure/03-wy1/code/src/redis/core.clj`):
- Only the body of `serve` changes: replaces the single `receive-message` + `send-message` call with a `loop`/`recur` that reads from the socket's `InputStream` into a byte buffer and responds with `+PONG\r\n` until the client disconnects
- All existing functions (`receive-message`, `send-message`, `handler`), comments (SO_REUSEADDR), and ordering are preserved from stage 2

**Hints** (`solutions/clojure/03-wy1/config.yml`):
- "How do I read data from a client connection?" — explains `getInputStream()` + byte array reading
- "How do I handle multiple commands?" — explains `loop`/`recur` pattern with disconnect detection

## Testing

All three stages pass with `course-sdk test clojure`:
- Stage 1 (Bind to a port): passed
- Stage 2 (Respond to PING): passed
- Stage 3 (Respond to multiple PINGs): passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0776014d-29d4-4571-b101-46b2464b9b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0776014d-29d4-4571-b101-46b2464b9b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

