### PR TITLE
Add Elixir stage 3 solution and hints (Respond to multiple PINGs)

### DIFF
--- a/solutions/elixir/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/elixir/03-wy1/code/.codecrafters/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+mix escript.build
+mv codecrafters_redis /tmp/codecrafters-build-redis-elixir

--- a/solutions/elixir/03-wy1/code/.codecrafters/run.sh
+++ b/solutions/elixir/03-wy1/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec /tmp/codecrafters-build-redis-elixir "$@"

--- a/solutions/elixir/03-wy1/code/.formatter.exs
+++ b/solutions/elixir/03-wy1/code/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/solutions/elixir/03-wy1/code/.gitattributes
+++ b/solutions/elixir/03-wy1/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/elixir/03-wy1/code/.gitignore
+++ b/solutions/elixir/03-wy1/code/.gitignore
@@ -1,0 +1,27 @@
+# Ignore the compiled binary
+/codecrafters_redis
+
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+app-*.tar
+

--- a/solutions/elixir/03-wy1/code/README.md
+++ b/solutions/elixir/03-wy1/code/README.md
@@ -1,0 +1,33 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for Elixir solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in `lib/main.ex`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `mix` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `lib/main.ex`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/elixir/03-wy1/code/codecrafters.yml
+++ b/solutions/elixir/03-wy1/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Elixir version used to run your code
+# on Codecrafters.
+#
+# Available versions: elixir-1.19
+buildpack: elixir-1.19

--- a/solutions/elixir/03-wy1/code/lib/main.ex
+++ b/solutions/elixir/03-wy1/code/lib/main.ex
@@ -1,0 +1,43 @@
+defmodule Server do
+  @moduledoc """
+  Your implementation of a Redis server
+  """
+
+  use Application
+
+  def start(_type, _args) do
+    Supervisor.start_link([{Task, fn -> Server.listen() end}], strategy: :one_for_one)
+  end
+
+  @doc """
+  Listen for incoming connections
+  """
+  def listen() do
+    # Since the tester restarts your program quite often, setting SO_REUSEADDR
+    # ensures that we don't run into 'Address already in use' errors
+    {:ok, socket} = :gen_tcp.listen(6379, [:binary, active: false, reuseaddr: true])
+    {:ok, client} = :gen_tcp.accept(socket)
+    serve(client)
+  end
+
+  defp serve(client) do
+    case :gen_tcp.recv(client, 0) do
+      {:ok, _data} ->
+        :gen_tcp.send(client, "+PONG\r\n")
+        serve(client)
+
+      {:error, :closed} ->
+        :ok
+    end
+  end
+end
+
+defmodule CLI do
+  def main(_args) do
+    # Start the Server application
+    {:ok, _pid} = Application.ensure_all_started(:codecrafters_redis)
+
+    # Run forever
+    Process.sleep(:infinity)
+  end
+end

--- a/solutions/elixir/03-wy1/code/mix.exs
+++ b/solutions/elixir/03-wy1/code/mix.exs
@@ -1,0 +1,31 @@
+defmodule App.MixProject do
+  # NOTE: You do not need to change anything in this file.
+  use Mix.Project
+
+  def project do
+    [
+      app: :codecrafters_redis,
+      version: "1.0.0",
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      escript: [main_module: CLI]
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {Server, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/solutions/elixir/03-wy1/code/your_program.sh
+++ b/solutions/elixir/03-wy1/code/your_program.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  mix escript.build
+  mv codecrafters_redis /tmp/codecrafters-build-redis-elixir
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec /tmp/codecrafters-build-redis-elixir "$@"

--- a/solutions/elixir/03-wy1/config.yml
+++ b/solutions/elixir/03-wy1/config.yml
@@ -1,0 +1,30 @@
+hints:
+  - title_markdown: "How do I read data from a client connection?"
+    body_markdown: |-
+      Use the [`:gen_tcp.recv`](https://www.erlang.org/doc/man/gen_tcp.html#recv-2) function to read data from the client:
+
+      ```elixir
+      {:ok, data} = :gen_tcp.recv(client, 0)
+      ```
+
+      - The second argument `0` means receive all available bytes.
+      - `:gen_tcp.recv` returns `{:ok, data}` on success, or `{:error, :closed}` when the client has closed the connection.
+
+  - title_markdown: "How do I handle multiple commands?"
+    body_markdown: |-
+      Use a recursive function to keep reading commands and sending responses. Use pattern matching on the result of `:gen_tcp.recv` to decide whether to continue or stop:
+
+      ```elixir
+      defp serve(client) do
+        case :gen_tcp.recv(client, 0) do
+          {:ok, _data} ->
+            :gen_tcp.send(client, "+PONG\r\n")
+            serve(client)
+
+          {:error, :closed} ->
+            :ok
+        end
+      end
+      ```
+
+      This function will keep reading commands and responding with `+PONG\r\n` until the client closes the connection.

--- a/solutions/elixir/03-wy1/diff/lib/main.ex.diff
+++ b/solutions/elixir/03-wy1/diff/lib/main.ex.diff
@@ -1,0 +1,45 @@
+@@ -1,32 +1,43 @@
+ defmodule Server do
+   @moduledoc """
+   Your implementation of a Redis server
+   """
+
+   use Application
+
+   def start(_type, _args) do
+     Supervisor.start_link([{Task, fn -> Server.listen() end}], strategy: :one_for_one)
+   end
+
+   @doc """
+   Listen for incoming connections
+   """
+   def listen() do
+     # Since the tester restarts your program quite often, setting SO_REUSEADDR
+     # ensures that we don't run into 'Address already in use' errors
+     {:ok, socket} = :gen_tcp.listen(6379, [:binary, active: false, reuseaddr: true])
+     {:ok, client} = :gen_tcp.accept(socket)
+-    :gen_tcp.send(client, "+PONG\r\n")
++    serve(client)
++  end
++
++  defp serve(client) do
++    case :gen_tcp.recv(client, 0) do
++      {:ok, _data} ->
++        :gen_tcp.send(client, "+PONG\r\n")
++        serve(client)
++
++      {:error, :closed} ->
++        :ok
++    end
+   end
+ end
+
+ defmodule CLI do
+   def main(_args) do
+     # Start the Server application
+     {:ok, _pid} = Application.ensure_all_started(:codecrafters_redis)
+
+     # Run forever
+     Process.sleep(:infinity)
+   end
+ end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds the solution and hints for Elixir base stage 3 (`03-wy1` — "Respond to multiple PINGs").

## Changes

### Solution (`solutions/elixir/03-wy1/code/lib/main.ex`)

The key change from stage 2 is replacing the single `:gen_tcp.send` call with a recursive `serve/1` function that:
1. Reads from the client connection using `:gen_tcp.recv(client, 0)`
2. Responds with `+PONG\r\n` for each command received
3. Recurses to handle the next command
4. Stops when the client disconnects (`{:error, :closed}`)

This is the idiomatic Elixir approach using tail-recursive pattern matching, mirroring how the Python reference solution uses a `while True` loop with `recv()`/`sendall()`.

### Hints (`solutions/elixir/03-wy1/config.yml`)

Two hints following the same structure and tone as the Python stage 3 hints, adapted for Elixir idioms:
1. **"How do I read data from a client connection?"** — explains `:gen_tcp.recv` usage and return values
2. **"How do I handle multiple commands?"** — shows the recursive `serve/1` pattern with `case` matching

## Testing

All stages pass with `course-sdk test elixir`:
- Starter code: passed
- Stage 01-jm1: passed
- Stage 02-rg2: passed
- Stage 03-wy1: passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4d0bee0-a910-44d2-939d-7f645373f207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4d0bee0-a910-44d2-939d-7f645373f207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

