### PR TITLE
Add Zig stage 3 solution and hints: Respond to multiple PINGs (Zig 0.16)

### DIFF
--- a/solutions/zig/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/zig/03-wy1/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+zig build

--- a/solutions/zig/03-wy1/code/.codecrafters/run.sh
+++ b/solutions/zig/03-wy1/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec "$(dirname "$0")"/zig-out/bin/main "$@"

--- a/solutions/zig/03-wy1/code/.gitattributes
+++ b/solutions/zig/03-wy1/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/zig/03-wy1/code/.gitignore
+++ b/solutions/zig/03-wy1/code/.gitignore
@@ -1,0 +1,18 @@
+# Zig build artifacts
+main
+zig-cache/
+.zig-cache/
+zig-out/
+
+# Compiled binary output
+bin/
+!bin/.gitkeep
+
+# Ignore any .o or .h files generated during build
+*.o
+*.h
+
+# Ignore OS and editor specific files
+**/.DS_Store
+*.swp
+*~

--- a/solutions/zig/03-wy1/code/README.md
+++ b/solutions/zig/03-wy1/code/README.md
@@ -1,0 +1,33 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for Zig solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in `src/main.zig`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `zig (0.15)` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `src/main.zig`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/zig/03-wy1/code/README.md
+++ b/solutions/zig/03-wy1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/zig/03-wy1/code/build.zig
+++ b/solutions/zig/03-wy1/code/build.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+// Learn more about this file here: https://ziglang.org/learn/build-system
+pub fn build(b: *std.Build) void {
+    const exe = b.addExecutable(.{
+        .name = "main",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = b.graph.host,
+        }),
+    });
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+}

--- a/solutions/zig/03-wy1/code/build.zig.zon
+++ b/solutions/zig/03-wy1/code/build.zig.zon
@@ -1,0 +1,69 @@
+.{
+    .name = .codecrafters_redis,
+    .fingerprint = 0xf806bb97907ce4a5,
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    .minimum_zig_version = "0.15.1",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        //.example = .{
+        //    // When updating this field to a new URL, be sure to delete the corresponding
+        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
+        //    // the new URL.
+        //    .url = "https://example.com/foo.tar.gz",
+        //
+        //    // This is computed from the file contents of the directory of files that is
+        //    // obtained after fetching `url` and applying the inclusion rules given by
+        //    // `paths`.
+        //    //
+        //    // This field is the source of truth; packages do not come from a `url`; they
+        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
+        //    // obtain a package matching this `hash`.
+        //    //
+        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
+        //    .hash = "...",
+        //
+        //    // When this is provided, the package is found in a directory relative to the
+        //    // build root. In this case the package's hash is irrelevant and therefore not
+        //    // computed. This field and `url` are mutually exclusive.
+        //    .path = "foo",
+
+        //    // When this is set to `true`, a package is declared to be lazily
+        //    // fetched. This makes the dependency only get fetched if it is
+        //    // actually used.
+        //    .lazy = false,
+        //},
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package.
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        // This makes *all* files, recursively, included in this package. It is generally
+        // better to explicitly list the files and directories instead, to insure that
+        // fetching from tarballs, file system paths, and version control all result
+        // in the same contents hash.
+        "",
+        // For example...
+        //"build.zig",
+        //"build.zig.zon",
+        //"src",
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/solutions/zig/03-wy1/code/build.zig.zon
+++ b/solutions/zig/03-wy1/code/build.zig.zon
@@ -9,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/solutions/zig/03-wy1/code/codecrafters.yml
+++ b/solutions/zig/03-wy1/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Zig version used to run your code
+# on Codecrafters.
+#
+# Available versions: zig-0.15.2
+buildpack: zig-0.15.2

--- a/solutions/zig/03-wy1/code/codecrafters.yml
+++ b/solutions/zig/03-wy1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/solutions/zig/03-wy1/code/src/main.zig
+++ b/solutions/zig/03-wy1/code/src/main.zig
@@ -1,26 +1,25 @@
 const std = @import("std");
-const stdout = std.fs.File.stdout();
-const net = std.net;
 
-pub fn main() !void {
-    const address = try net.Address.resolveIp("127.0.0.1", 6379);
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
 
-    var listener = try address.listen(.{
+    const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
+
+    var server = try address.listen(io, .{
         .reuse_address = true,
     });
-    defer listener.deinit();
+    defer server.deinit(io);
 
+    const connection = try server.accept(io);
+    defer connection.close(io);
+
+    var connection_writer = connection.writer(io, &.{});
+
+    var buf: [1024]u8 = undefined;
+    var data = [_][]u8{&buf};
     while (true) {
-        const connection = try listener.accept();
-        defer connection.stream.close();
-
-        try stdout.writeAll("accepted new connection");
-
-        var buf: [1024]u8 = undefined;
-        while (true) {
-            const bytes_read = try connection.stream.read(&buf);
-            if (bytes_read == 0) break;
-            try connection.stream.writeAll("+PONG\r\n");
-        }
+        const bytes_read = io.vtable.netRead(io.userdata, connection.socket.handle, &data) catch break;
+        if (bytes_read == 0) break;
+        try connection_writer.interface.writeAll("+PONG\r\n");
     }
 }

--- a/solutions/zig/03-wy1/code/src/main.zig
+++ b/solutions/zig/03-wy1/code/src/main.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+const stdout = std.fs.File.stdout();
+const net = std.net;
+
+pub fn main() !void {
+    const address = try net.Address.resolveIp("127.0.0.1", 6379);
+
+    var listener = try address.listen(.{
+        .reuse_address = true,
+    });
+    defer listener.deinit();
+
+    while (true) {
+        const connection = try listener.accept();
+        defer connection.stream.close();
+
+        try stdout.writeAll("accepted new connection");
+
+        var buf: [1024]u8 = undefined;
+        while (true) {
+            const bytes_read = try connection.stream.read(&buf);
+            if (bytes_read == 0) break;
+            try connection.stream.writeAll("+PONG\r\n");
+        }
+    }
+}

--- a/solutions/zig/03-wy1/code/your_program.sh
+++ b/solutions/zig/03-wy1/code/your_program.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  zig build
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec "$(dirname "$0")"/zig-out/bin/main "$@"

--- a/solutions/zig/03-wy1/config.yml
+++ b/solutions/zig/03-wy1/config.yml
@@ -1,26 +1,30 @@
 hints:
   - title_markdown: "How do I read data from a client connection?"
     body_markdown: |-
-      Use the [`read()`](https://ziglang.org/documentation/master/std/#std;net.Stream) method on the connection's stream to read data into a buffer:
+      Use the [`netRead()`](https://ziglang.org/documentation/0.16.0/std/#std.Io.VTable.netRead) function on the IO vtable to read data from the connection into a buffer:
 
       ```zig
       var buf: [1024]u8 = undefined;
-      const bytes_read = try connection.stream.read(&buf);
+      var data = [_][]u8{&buf};
+      const bytes_read = io.vtable.netRead(io.userdata, connection.socket.handle, &data) catch break;
       ```
 
-      - The `read()` method returns the number of bytes read.
+      - `netRead()` returns the number of bytes read.
       - It returns `0` when the client has closed the connection.
 
   - title_markdown: "How do I handle multiple commands?"
     body_markdown: |-
-      Wrap your `read()` and `writeAll()` calls in a loop. Break out of the loop when the client disconnects (i.e., when `read()` returns `0`):
+      Wrap your read and write calls in a loop. Break out of the loop when the client disconnects (i.e., when `netRead()` returns `0`):
 
       ```zig
+      var connection_writer = connection.writer(io, &.{});
+
       var buf: [1024]u8 = undefined;
+      var data = [_][]u8{&buf};
       while (true) {
-          const bytes_read = try connection.stream.read(&buf);
+          const bytes_read = io.vtable.netRead(io.userdata, connection.socket.handle, &data) catch break;
           if (bytes_read == 0) break;
-          try connection.stream.writeAll("+PONG\r\n");
+          try connection_writer.interface.writeAll("+PONG\r\n");
       }
       ```
 

--- a/solutions/zig/03-wy1/config.yml
+++ b/solutions/zig/03-wy1/config.yml
@@ -1,0 +1,27 @@
+hints:
+  - title_markdown: "How do I read data from a client connection?"
+    body_markdown: |-
+      Use the [`read()`](https://ziglang.org/documentation/master/std/#std;net.Stream) method on the connection's stream to read data into a buffer:
+
+      ```zig
+      var buf: [1024]u8 = undefined;
+      const bytes_read = try connection.stream.read(&buf);
+      ```
+
+      - The `read()` method returns the number of bytes read.
+      - It returns `0` when the client has closed the connection.
+
+  - title_markdown: "How do I handle multiple commands?"
+    body_markdown: |-
+      Wrap your `read()` and `writeAll()` calls in a loop. Break out of the loop when the client disconnects (i.e., when `read()` returns `0`):
+
+      ```zig
+      var buf: [1024]u8 = undefined;
+      while (true) {
+          const bytes_read = try connection.stream.read(&buf);
+          if (bytes_read == 0) break;
+          try connection.stream.writeAll("+PONG\r\n");
+      }
+      ```
+
+      This loop will keep reading commands and responding with `+PONG\r\n` until the client closes the connection.

--- a/solutions/zig/03-wy1/diff/src/main.zig.diff
+++ b/solutions/zig/03-wy1/diff/src/main.zig.diff
@@ -1,0 +1,29 @@
+@@ -1,20 +1,26 @@
+ const std = @import("std");
+ const stdout = std.fs.File.stdout();
+ const net = std.net;
+
+ pub fn main() !void {
+     const address = try net.Address.resolveIp("127.0.0.1", 6379);
+
+     var listener = try address.listen(.{
+         .reuse_address = true,
+     });
+     defer listener.deinit();
+
+     while (true) {
+         const connection = try listener.accept();
++        defer connection.stream.close();
+
+         try stdout.writeAll("accepted new connection");
+-        try connection.stream.writeAll("+PONG\r\n");
+-        connection.stream.close();
++
++        var buf: [1024]u8 = undefined;
++        while (true) {
++            const bytes_read = try connection.stream.read(&buf);
++            if (bytes_read == 0) break;
++            try connection.stream.writeAll("+PONG\r\n");
++        }
+     }
+ }

--- a/solutions/zig/03-wy1/diff/src/main.zig.diff
+++ b/solutions/zig/03-wy1/diff/src/main.zig.diff
@@ -1,29 +1,27 @@
-@@ -1,20 +1,26 @@
+@@ -1,18 +1,25 @@
  const std = @import("std");
- const stdout = std.fs.File.stdout();
- const net = std.net;
 
- pub fn main() !void {
-     const address = try net.Address.resolveIp("127.0.0.1", 6379);
+ pub fn main(init: std.process.Init) !void {
+     const io = init.io;
 
-     var listener = try address.listen(.{
+     const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
+
+     var server = try address.listen(io, .{
          .reuse_address = true,
      });
-     defer listener.deinit();
+     defer server.deinit(io);
 
-     while (true) {
-         const connection = try listener.accept();
-+        defer connection.stream.close();
+     const connection = try server.accept(io);
+     defer connection.close(io);
 
-         try stdout.writeAll("accepted new connection");
--        try connection.stream.writeAll("+PONG\r\n");
--        connection.stream.close();
+     var connection_writer = connection.writer(io, &.{});
+-    try connection_writer.interface.writeAll("+PONG\r\n");
 +
-+        var buf: [1024]u8 = undefined;
-+        while (true) {
-+            const bytes_read = try connection.stream.read(&buf);
-+            if (bytes_read == 0) break;
-+            try connection.stream.writeAll("+PONG\r\n");
-+        }
-     }
++    var buf: [1024]u8 = undefined;
++    var data = [_][]u8{&buf};
++    while (true) {
++        const bytes_read = io.vtable.netRead(io.userdata, connection.socket.handle, &data) catch break;
++        if (bytes_read == 0) break;
++        try connection_writer.interface.writeAll("+PONG\r\n");
++    }
  }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the solution and hints for Zig stage 3 ("Respond to multiple PINGs"), updated for Zig 0.16.

## Solution

The stage 3 solution extends the stage 2 solution by replacing the single `writeAll("+PONG\r\n")` with a read loop that:
1. Reads data from the connection using `io.vtable.netRead()` into a buffer
2. Responds with `+PONG\r\n` for each chunk received
3. Breaks when the client disconnects (read returns 0 or errors)
4. Uses `connection.writer(io, &.{})` for writing responses

Uses `io.vtable.netRead()` directly instead of `connection.reader()` due to a known `Stream.Reader` bug in Zig 0.16.0 (fixed post-release in commit `e0e463bcf7`).

## Hints

Two hints are provided in `config.yml`:
1. **"How do I read data from a client connection?"** — explains `netRead()` usage and the scatter/gather buffer pattern
2. **"How do I handle multiple commands?"** — shows the complete read/write loop

Documentation links are pinned to `0.16.0` to prevent drift from Zig's master branch.

## Testing

All 3 Zig stages pass via `course-sdk test zig`:
- Stage 1 (Bind to a port): passed
- Stage 2 (Respond to PING): passed
- Stage 3 (Respond to multiple PINGs): passed (3 consecutive PINGs on the same connection all received PONG)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9aa69ed4-6cb0-4a5b-ae0e-4ae170227dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9aa69ed4-6cb0-4a5b-ae0e-4ae170227dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

