### PR TITLE
Add Scala solution and hints for stage 3 (Respond to multiple PINGs)

### DIFF
--- a/solutions/scala/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/scala/03-wy1/code/.codecrafters/compile.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+scala-cli package src/main/scala/ \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
+  -o /tmp/codecrafters-build-redis-scala

--- a/solutions/scala/03-wy1/code/.codecrafters/run.sh
+++ b/solutions/scala/03-wy1/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec java -jar /tmp/codecrafters-build-redis-scala "$@"

--- a/solutions/scala/03-wy1/code/.gitattributes
+++ b/solutions/scala/03-wy1/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/scala/03-wy1/code/.gitignore
+++ b/solutions/scala/03-wy1/code/.gitignore
@@ -1,0 +1,17 @@
+out/
+.bloop/
+.metals/
+.vscode/
+.idea/
+.cursor/
+
+.bsp
+.scala-build
+dest/
+target/
+
+*/scoverage.coverage
+
+# ignore vim backup files
+*.sw[op]
+.DS_Store

--- a/solutions/scala/03-wy1/code/README.md
+++ b/solutions/scala/03-wy1/code/README.md
@@ -1,0 +1,34 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for Scala solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in
+`src/main/scala/codecrafters_redis/App.scala`. Study and uncomment the relevant
+code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `scala-cli` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `src/main/scala/codecrafters_redis/App.scala`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/scala/03-wy1/code/codecrafters.yml
+++ b/solutions/scala/03-wy1/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Scala version used to run your code
+# on Codecrafters.
+#
+# Available versions: scala-3.8
+buildpack: scala-3.8

--- a/solutions/scala/03-wy1/code/src/main/scala/codecrafters_redis/App.scala
+++ b/solutions/scala/03-wy1/code/src/main/scala/codecrafters_redis/App.scala
@@ -1,0 +1,18 @@
+package codecrafters_redis
+
+import java.net.{InetSocketAddress, ServerSocket}
+
+object Server {
+  def main(args: Array[String]): Unit = {
+    val serverSocket = new ServerSocket()
+    serverSocket.bind(new InetSocketAddress("localhost", 6379))
+    val clientSocket = serverSocket.accept() // wait for client
+    val inputStream = clientSocket.getInputStream
+    val buffer = new Array[Byte](1024)
+    var bytesRead = inputStream.read(buffer)
+    while (bytesRead != -1) {
+      clientSocket.getOutputStream.write("+PONG\r\n".getBytes())
+      bytesRead = inputStream.read(buffer)
+    }
+  }
+}

--- a/solutions/scala/03-wy1/code/your_program.sh
+++ b/solutions/scala/03-wy1/code/your_program.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  scala-cli package src/main/scala/ \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
+    -o /tmp/codecrafters-build-redis-scala
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec java -jar /tmp/codecrafters-build-redis-scala "$@"

--- a/solutions/scala/03-wy1/config.yml
+++ b/solutions/scala/03-wy1/config.yml
@@ -1,0 +1,27 @@
+hints:
+  - title_markdown: "How do I read data from a client connection?"
+    body_markdown: |-
+      Use the [`read(byte[])`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/InputStream.html#read(byte%5B%5D)) method on the client's input stream to read data:
+
+      ```scala
+      val buffer = new Array[Byte](1024)
+      val bytesRead = inputStream.read(buffer)
+      ```
+
+      - The `1024` size specifies the maximum number of bytes to read at once.
+      - `read()` returns `-1` when the client has closed the connection.
+  - title_markdown: "How do I handle multiple commands?"
+    body_markdown: |-
+      Wrap your `read()` and `write()` calls in a loop. Break out of the loop when the client disconnects (i.e., when `read()` returns `-1`):
+
+      ```scala
+      val inputStream = clientSocket.getInputStream
+      val buffer = new Array[Byte](1024)
+      var bytesRead = inputStream.read(buffer)
+      while (bytesRead != -1) {
+        clientSocket.getOutputStream.write("+PONG\r\n".getBytes())
+        bytesRead = inputStream.read(buffer)
+      }
+      ```
+
+      This loop will keep reading commands and responding with `+PONG\r\n` until the client closes the connection.

--- a/solutions/scala/03-wy1/diff/src/main/scala/codecrafters_redis/App.scala.diff
+++ b/solutions/scala/03-wy1/diff/src/main/scala/codecrafters_redis/App.scala.diff
@@ -1,0 +1,20 @@
+@@ -1,12 +1,18 @@
+ package codecrafters_redis
+
+ import java.net.{InetSocketAddress, ServerSocket}
+
+ object Server {
+   def main(args: Array[String]): Unit = {
+     val serverSocket = new ServerSocket()
+     serverSocket.bind(new InetSocketAddress("localhost", 6379))
+     val clientSocket = serverSocket.accept() // wait for client
+-    clientSocket.getOutputStream.write("+PONG\r\n".getBytes())
++    val inputStream = clientSocket.getInputStream
++    val buffer = new Array[Byte](1024)
++    var bytesRead = inputStream.read(buffer)
++    while (bytesRead != -1) {
++      clientSocket.getOutputStream.write("+PONG\r\n".getBytes())
++      bytesRead = inputStream.read(buffer)
++    }
+   }
+ }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds the solution and hints for **Scala stage 3** (`wy1` — "Respond to multiple PINGs").

## Changes

### Solution (`solutions/scala/03-wy1/code/`)
- Incremental change from stage 2: replaces the single `write("+PONG\r\n")` call with a loop that reads from the client's `InputStream` and responds with `+PONG\r\n` for each command received, until the client closes the connection.

### Hints (`solutions/scala/03-wy1/config.yml`)
Two hints following the same pattern as existing Python and Scala stage 2 hints:
1. **"How do I read data from a client connection?"** — explains `InputStream.read(byte[])` with Scala example code.
2. **"How do I handle multiple commands?"** — explains the read/write loop pattern with a complete Scala example.

### Diff (`solutions/scala/03-wy1/diff/`)
Auto-generated by `course-sdk compile`.

## Testing

All stages pass via `course-sdk test scala`:

```
[stage-2] Running tests for Stage 2: Respond to PING
[stage-2] $ ./your_program.sh
[stage-2] [client] $ redis-cli PING
[stage-2] [client] ✔︎ Received "PONG"
[stage-2] Test passed.

[stage-3] Running tests for Stage 3: Respond to multiple PINGs
[stage-3] $ ./your_program.sh
[stage-3] [client-1] $ redis-cli PING
[stage-3] [client-1] ✔︎ Received "PONG"
[stage-3] [client-1] > PING
[stage-3] [client-1] ✔︎ Received "PONG"
[stage-3] [client-1] > PING
[stage-3] [client-1] ✔︎ Received "PONG"
[stage-3] Test passed.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0eeabdb5-b333-427c-b5c7-7bb629601358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0eeabdb5-b333-427c-b5c7-7bb629601358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

