### PR TITLE
Add solutions and hints for C stage 3 (Respond to multiple PINGs)

### DIFF
--- a/solutions/c/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/c/03-wy1/code/.codecrafters/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+cmake --build ./build

--- a/solutions/c/03-wy1/code/.codecrafters/run.sh
+++ b/solutions/c/03-wy1/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec $(dirname "$0")/build/redis "$@"

--- a/solutions/c/03-wy1/code/.gitattributes
+++ b/solutions/c/03-wy1/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/c/03-wy1/code/.gitignore
+++ b/solutions/c/03-wy1/code/.gitignore
@@ -1,0 +1,55 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+build
+vcpkg_installed

--- a/solutions/c/03-wy1/code/CMakeLists.txt
+++ b/solutions/c/03-wy1/code/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(codecrafters-redis)
+
+file(GLOB_RECURSE SOURCE_FILES src/*.c src/*.h)
+
+set(CMAKE_C_STANDARD 23) # Enable the C23 standard
+
+add_executable(redis ${SOURCE_FILES})

--- a/solutions/c/03-wy1/code/README.md
+++ b/solutions/c/03-wy1/code/README.md
@@ -1,0 +1,33 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/redis.png)
+
+This is a starting point for C solutions to the
+["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+
+In this challenge, you'll build a toy Redis clone that's capable of handling
+basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
+event loops, the Redis protocol and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your Redis implementation is in `src/main.c`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+That's all!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `cmake` installed locally
+1. Run `./your_program.sh` to run your Redis server, which is implemented in
+   `src/main.c`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/c/03-wy1/code/codecrafters.yml
+++ b/solutions/c/03-wy1/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the C version used to run your code
+# on Codecrafters.
+#
+# Available versions: c-23
+buildpack: c-23

--- a/solutions/c/03-wy1/code/src/main.c
+++ b/solutions/c/03-wy1/code/src/main.c
@@ -1,0 +1,71 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+int main() {
+	// Disable output buffering
+	setbuf(stdout, NULL);
+	setbuf(stderr, NULL);
+	
+	int server_fd, client_addr_len;
+	struct sockaddr_in client_addr;
+
+	server_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (server_fd == -1) {
+		printf("Socket creation failed: %s...\n", strerror(errno));
+		return 1;
+	}
+
+	// Since the tester restarts your program quite often, setting SO_REUSEADDR
+	// ensures that we don't run into 'Address already in use' errors
+	int reuse = 1;
+	if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0) {
+		printf("SO_REUSEADDR failed: %s \n", strerror(errno));
+		return 1;
+	}
+
+	struct sockaddr_in serv_addr = { .sin_family = AF_INET ,
+									 .sin_port = htons(6379),
+									 .sin_addr = { htonl(INADDR_ANY) },
+									};
+
+	if (bind(server_fd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) != 0) {
+		printf("Bind failed: %s \n", strerror(errno));
+		return 1;
+	}
+
+	int connection_backlog = 5;
+	if (listen(server_fd, connection_backlog) != 0) {
+		printf("Listen failed: %s \n", strerror(errno));
+		return 1;
+	}
+
+	printf("Waiting for a client to connect...\n");
+	client_addr_len = sizeof(client_addr);
+
+	int client_fd = accept(server_fd, (struct sockaddr *) &client_addr, &client_addr_len);
+	if (client_fd == -1) {
+		printf("Accept failed: %s \n", strerror(errno));
+		close(server_fd);
+		return 1;
+	}
+	printf("Client connected\n");
+
+	char buffer[1024];
+	const char *response = "+PONG\r\n";
+	while (1) {
+		ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer), 0);
+		if (bytes_read <= 0) break;
+		send(client_fd, response, strlen(response), 0);
+	}
+
+	close(client_fd);
+	close(server_fd);
+
+	return 0;
+}

--- a/solutions/c/03-wy1/code/vcpkg-configuration.json
+++ b/solutions/c/03-wy1/code/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/solutions/c/03-wy1/code/vcpkg.json
+++ b/solutions/c/03-wy1/code/vcpkg.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": []
+}

--- a/solutions/c/03-wy1/code/your_program.sh
+++ b/solutions/c/03-wy1/code/your_program.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+  cmake --build ./build
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec $(dirname "$0")/build/redis "$@"

--- a/solutions/c/03-wy1/config.yml
+++ b/solutions/c/03-wy1/config.yml
@@ -1,0 +1,28 @@
+hints:
+  - title_markdown: "How do I read data from a client connection?"
+    body_markdown: |-
+      Use the [`recv()`](https://man7.org/linux/man-pages/man2/recv.2.html) function on the client's socket to read data:
+
+      ```c
+      char buffer[1024];
+      ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer), 0);
+      ```
+
+      - The `sizeof(buffer)` argument specifies the maximum number of bytes to receive at once.
+      - `recv()` returns `0` when the client has closed the connection, and `-1` on error.
+
+  - title_markdown: "How do I handle multiple commands?"
+    body_markdown: |-
+      Wrap your `recv()` and `send()` calls in a loop. Break out of the loop when the client disconnects (i.e., when `recv()` returns `0` or a negative value):
+
+      ```c
+      char buffer[1024];
+      const char *response = "+PONG\r\n";
+      while (1) {
+          ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer), 0);
+          if (bytes_read <= 0) break;
+          send(client_fd, response, strlen(response), 0);
+      }
+      ```
+
+      This loop will keep reading commands and responding with `+PONG\r\n` until the client closes the connection.

--- a/solutions/c/03-wy1/diff/src/main.c.diff
+++ b/solutions/c/03-wy1/diff/src/main.c.diff
@@ -1,0 +1,41 @@
+@@ -34,35 +34,38 @@
+ 									 .sin_addr = { htonl(INADDR_ANY) },
+ 									};
+
+ 	if (bind(server_fd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) != 0) {
+ 		printf("Bind failed: %s \n", strerror(errno));
+ 		return 1;
+ 	}
+
+ 	int connection_backlog = 5;
+ 	if (listen(server_fd, connection_backlog) != 0) {
+ 		printf("Listen failed: %s \n", strerror(errno));
+ 		return 1;
+ 	}
+
+ 	printf("Waiting for a client to connect...\n");
+ 	client_addr_len = sizeof(client_addr);
+
+ 	int client_fd = accept(server_fd, (struct sockaddr *) &client_addr, &client_addr_len);
+ 	if (client_fd == -1) {
+ 		printf("Accept failed: %s \n", strerror(errno));
+ 		close(server_fd);
+ 		return 1;
+ 	}
+ 	printf("Client connected\n");
+
++	char buffer[1024];
+ 	const char *response = "+PONG\r\n";
+-	if (send(client_fd, response, strlen(response), 0) == -1) {
+-		printf("Send failed: %s \n", strerror(errno));
++	while (1) {
++		ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer), 0);
++		if (bytes_read <= 0) break;
++		send(client_fd, response, strlen(response), 0);
+ 	}
+
+ 	close(client_fd);
+ 	close(server_fd);
+
+ 	return 0;
+ }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the solution and hints for C stage 3 (`wy1` - "Respond to multiple PINGs").

## Changes

### Solution (`solutions/c/03-wy1/code/src/main.c`)
Minimal incremental change from stage 2: replaces the single `send()` call with a `recv()`/`send()` loop that continuously reads commands and responds with `+PONG\r\n` until the client disconnects.

### Hints (`solutions/c/03-wy1/config.yml`)
Two hints following the same structure and tone as the existing C stage 2 hints and the Python stage 3 hints:
1. **How do I read data from a client connection?** — Introduces `recv()` with a code example.
2. **How do I handle multiple commands?** — Shows the full `recv()`/`send()` loop pattern.

## Testing

All 3 C stages pass `course-sdk test c`:

Test results summary:
[test_results_summary.log](https://cursor.com/agents/bc-e93c863c-a07a-45de-89c9-8afb7e3a2a82/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_results_summary.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93c863c-a07a-45de-89c9-8afb7e3a2a82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93c863c-a07a-45de-89c9-8afb7e3a2a82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

