### PR TITLE
CC-2208: Upgrade Zig to 0.16

### DIFF
--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/zig/build.zig.zon
+++ b/compiled_starters/zig/build.zig.zon
@@ -9,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/compiled_starters/zig/codecrafters.yml
+++ b/compiled_starters/zig/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -1,24 +1,22 @@
 const std = @import("std");
-const stdout = std.fs.File.stdout();
-const net = std.net;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    try stdout.writeAll("Logs from your program will appear here!");
+    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!");
 
     // Uncomment the code below to pass the first stage
     //
-    // const address = try net.Address.resolveIp("127.0.0.1", 6379);
+    // const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
     //
-    // var listener = try address.listen(.{
+    // var server = try address.listen(io, .{
     //     .reuse_address = true,
     // });
-    // defer listener.deinit();
+    // defer server.deinit(io);
     //
-    // while (true) {
-    //     const connection = try listener.accept();
+    // const connection = try server.accept(io);
+    // defer connection.close(io);
     //
-    //     try stdout.writeAll("accepted new connection");
-    //     connection.stream.close();
-    // }
+    // try std.Io.File.writeStreamingAll(std.Io.File.stdout(), io, "accepted new connection");
 }

--- a/dockerfiles/zig-0.16.Dockerfile
+++ b/dockerfiles/zig-0.16.Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM debian:trixie
+
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        curl \
+        xz-utils \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install Zig
+RUN curl -O https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz \
+    && tar -xf zig-x86_64-linux-0.16.0.tar.xz \
+    && mv zig-x86_64-linux-0.16.0 /usr/local/zig \
+    && rm zig-x86_64-linux-0.16.0.tar.xz
+
+# Add Zig to PATH
+ENV PATH="/usr/local/zig:${PATH}"
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="build.zig,build.zig.zon"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs zig build
+RUN .codecrafters/compile.sh
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv /app/.zig-cache /app-cached/.zig-cache || true

--- a/solutions/zig/01-jm1/code/README.md
+++ b/solutions/zig/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/zig/01-jm1/code/build.zig.zon
+++ b/solutions/zig/01-jm1/code/build.zig.zon
@@ -9,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/solutions/zig/01-jm1/code/codecrafters.yml
+++ b/solutions/zig/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/solutions/zig/01-jm1/code/src/main.zig
+++ b/solutions/zig/01-jm1/code/src/main.zig
@@ -1,19 +1,17 @@
 const std = @import("std");
-const stdout = std.fs.File.stdout();
-const net = std.net;
 
-pub fn main() !void {
-    const address = try net.Address.resolveIp("127.0.0.1", 6379);
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
 
-    var listener = try address.listen(.{
+    const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
+
+    var server = try address.listen(io, .{
         .reuse_address = true,
     });
-    defer listener.deinit();
+    defer server.deinit(io);
 
-    while (true) {
-        const connection = try listener.accept();
+    const connection = try server.accept(io);
+    defer connection.close(io);
 
-        try stdout.writeAll("accepted new connection");
-        connection.stream.close();
-    }
+    try std.Io.File.writeStreamingAll(std.Io.File.stdout(), io, "accepted new connection");
 }

--- a/solutions/zig/01-jm1/diff/src/main.zig.diff
+++ b/solutions/zig/01-jm1/diff/src/main.zig.diff
@@ -1,37 +1,33 @@
-@@ -1,24 +1,19 @@
+@@ -1,22 +1,17 @@
  const std = @import("std");
- const stdout = std.fs.File.stdout();
- const net = std.net;
 
- pub fn main() !void {
+ pub fn main(init: std.process.Init) !void {
+     const io = init.io;
+
 -    // You can use print statements as follows for debugging, they'll be visible when running tests.
--    try stdout.writeAll("Logs from your program will appear here!");
-+    const address = try net.Address.resolveIp("127.0.0.1", 6379);
+-    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!");
++    const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
 
 -    // Uncomment the code below to pass the first stage
 -    //
--    // const address = try net.Address.resolveIp("127.0.0.1", 6379);
+-    // const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
 -    //
--    // var listener = try address.listen(.{
+-    // var server = try address.listen(io, .{
 -    //     .reuse_address = true,
 -    // });
--    // defer listener.deinit();
+-    // defer server.deinit(io);
 -    //
--    // while (true) {
--    //     const connection = try listener.accept();
+-    // const connection = try server.accept(io);
+-    // defer connection.close(io);
 -    //
--    //     try stdout.writeAll("accepted new connection");
--    //     connection.stream.close();
--    // }
-+    var listener = try address.listen(.{
+-    // try std.Io.File.writeStreamingAll(std.Io.File.stdout(), io, "accepted new connection");
++    var server = try address.listen(io, .{
 +        .reuse_address = true,
 +    });
-+    defer listener.deinit();
++    defer server.deinit(io);
 +
-+    while (true) {
-+        const connection = try listener.accept();
++    const connection = try server.accept(io);
++    defer connection.close(io);
 +
-+        try stdout.writeAll("accepted new connection");
-+        connection.stream.close();
-+    }
++    try std.Io.File.writeStreamingAll(std.Io.File.stdout(), io, "accepted new connection");
  }

--- a/solutions/zig/02-rg2/code/README.md
+++ b/solutions/zig/02-rg2/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/zig/02-rg2/code/build.zig.zon
+++ b/solutions/zig/02-rg2/code/build.zig.zon
@@ -9,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/solutions/zig/02-rg2/code/codecrafters.yml
+++ b/solutions/zig/02-rg2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/solutions/zig/02-rg2/code/src/main.zig
+++ b/solutions/zig/02-rg2/code/src/main.zig
@@ -1,20 +1,18 @@
 const std = @import("std");
-const stdout = std.fs.File.stdout();
-const net = std.net;
 
-pub fn main() !void {
-    const address = try net.Address.resolveIp("127.0.0.1", 6379);
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
 
-    var listener = try address.listen(.{
+    const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
+
+    var server = try address.listen(io, .{
         .reuse_address = true,
     });
-    defer listener.deinit();
+    defer server.deinit(io);
 
-    while (true) {
-        const connection = try listener.accept();
+    const connection = try server.accept(io);
+    defer connection.close(io);
 
-        try stdout.writeAll("accepted new connection");
-        try connection.stream.writeAll("+PONG\r\n");
-        connection.stream.close();
-    }
+    var connection_writer = connection.writer(io, &.{});
+    try connection_writer.interface.writeAll("+PONG\r\n");
 }

--- a/solutions/zig/02-rg2/config.yml
+++ b/solutions/zig/02-rg2/config.yml
@@ -1,18 +1,19 @@
 hints:
   - title_markdown: "How do I access the client's TCP connection?"
     body_markdown: |-
-      Use the [`accept()`](https://ziglang.org/documentation/master/std/#std;net.Server) method on the listener to get the client connection:
+      Use the [`accept()`](https://ziglang.org/documentation/0.16.0/std/#std.Io.net.Server.accept) method on the server to get the client connection:
 
       ```zig
-      const connection = try listener.accept();
+      const connection = try server.accept(io);
       ```
 
   - title_markdown: "How do I send a response to the client?"
     body_markdown: |-
-      Use the [`writeAll()`](https://ziglang.org/documentation/master/std/#std;io.Writer.writeAll) method on the client's stream writer:
+      Use the [`writeAll()`](https://ziglang.org/documentation/0.16.0/std/#std.Io.Writer.writeAll) method on the client connection's writer interface:
 
       ```zig
-      try connection.stream.writer().writeAll("+PONG\r\n");
+      var connection_writer = connection.writer(io, &.{});
+      try connection_writer.interface.writeAll("+PONG\r\n");
       ```
 
       `+PONG\r\n` is the string "PONG" encoded as a [RESP simple string](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings).

--- a/solutions/zig/02-rg2/diff/src/main.zig.diff
+++ b/solutions/zig/02-rg2/diff/src/main.zig.diff
@@ -1,21 +1,20 @@
-@@ -1,19 +1,20 @@
+@@ -1,17 +1,18 @@
  const std = @import("std");
- const stdout = std.fs.File.stdout();
- const net = std.net;
 
- pub fn main() !void {
-     const address = try net.Address.resolveIp("127.0.0.1", 6379);
+ pub fn main(init: std.process.Init) !void {
+     const io = init.io;
 
-     var listener = try address.listen(.{
+     const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
+
+     var server = try address.listen(io, .{
          .reuse_address = true,
      });
-     defer listener.deinit();
+     defer server.deinit(io);
 
-     while (true) {
-         const connection = try listener.accept();
+     const connection = try server.accept(io);
+     defer connection.close(io);
 
-         try stdout.writeAll("accepted new connection");
-+        try connection.stream.writeAll("+PONG\r\n");
-         connection.stream.close();
-     }
+-    try std.Io.File.writeStreamingAll(std.Io.File.stdout(), io, "accepted new connection");
++    var connection_writer = connection.writer(io, &.{});
++    try connection_writer.interface.writeAll("+PONG\r\n");
  }

--- a/starter_templates/zig/code/build.zig.zon
+++ b/starter_templates/zig/code/build.zig.zon
@@ -9,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -1,24 +1,22 @@
 const std = @import("std");
-const stdout = std.fs.File.stdout();
-const net = std.net;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    try stdout.writeAll("Logs from your program will appear here!");
+    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!");
 
     // Uncomment the code below to pass the first stage
     //
-    // const address = try net.Address.resolveIp("127.0.0.1", 6379);
+    // const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
     //
-    // var listener = try address.listen(.{
+    // var server = try address.listen(io, .{
     //     .reuse_address = true,
     // });
-    // defer listener.deinit();
+    // defer server.deinit(io);
     //
-    // while (true) {
-    //     const connection = try listener.accept();
+    // const connection = try server.accept(io);
+    // defer connection.close(io);
     //
-    //     try stdout.writeAll("accepted new connection");
-    //     connection.stream.close();
-    // }
+    // try std.Io.File.writeStreamingAll(std.Io.File.stdout(), io, "accepted new connection");
 }

--- a/starter_templates/zig/config.yml
+++ b/starter_templates/zig/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: zig (0.15)
+  required_executable: zig (0.16)
   user_editable_file: src/main.zig


### PR DESCRIPTION
- Changed minimum Zig version in build.zig.zon files to 0.16.0
- Updated buildpack version in codecrafters.yml files to 0.16
- Modified README.md files to reflect the requirement for Zig 0.16
- Refactored main.zig files to use the new Zig I/O API, including changes to how connections are accepted and data is written
- Added Dockerfile for Zig 0.16 to facilitate building and running Zig applications

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Compiler/runtime upgrade plus non-trivial API refactors in starter code could cause build or runtime regressions if any Zig 0.16 I/O semantics differ from 0.15.
> 
> **Overview**
> Upgrades the Zig Redis challenge starter templates, compiled starters, and included solutions from Zig `0.15` to `0.16` (README requirements, `build.zig.zon` minimum version, and `codecrafters.yml` buildpack selection).
> 
> Refactors Zig starter/solution `main.zig` examples to Zig 0.16’s `std.Io` API: `main` now takes `std.process.Init`, networking uses `std.Io.net.IpAddress`/server accept with an `io` context, and output/writes switch to streaming writers (including updated hint text in `solutions/zig/02-rg2/config.yml`).
> 
> Adds a new `dockerfiles/zig-0.16.Dockerfile` to build/run submissions using Zig `0.16.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 175f5344cbf118e22586e55db2ab029f0bddff7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->