### PR TITLE
CC-2203: Upgrade Odin to dev-2026-04

### DIFF
--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin` installed locally
+1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.odin`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/odin/codecrafters.yml
+++ b/compiled_starters/odin/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.7
-buildpack: odin-2025.7
+# Available versions: odin-2026.4
+buildpack: odin-2026.4

--- a/dockerfiles/odin-2026.3.Dockerfile
+++ b/dockerfiles/odin-2026.3.Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM silkeh/clang:21-trixie
+
+WORKDIR /Odin-install
+RUN git clone --depth 1 -b dev-2026-03 https://github.com/odin-lang/Odin.git /Odin-install \
+    && git checkout dev-2026-03 \
+    && make
+
+RUN mkdir /opt/Odin \
+    && cp -R ./base ./core ./shared ./vendor ./odin /opt/Odin/
+
+WORKDIR /
+RUN rm -rf /Odin-install
+ENV PATH="/opt/Odin:${PATH}"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install language-specific dependencies
+RUN .codecrafters/compile.sh

--- a/dockerfiles/odin-2026.4.Dockerfile
+++ b/dockerfiles/odin-2026.4.Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM silkeh/clang:21-trixie
+
+WORKDIR /Odin-install
+RUN git clone --depth 1 -b dev-2026-04 https://github.com/odin-lang/Odin.git /Odin-install \
+    && git checkout dev-2026-04 \
+    && make
+
+RUN mkdir /opt/Odin \
+    && cp -R ./base ./core ./shared ./vendor ./odin /opt/Odin/
+
+WORKDIR /
+RUN rm -rf /Odin-install
+ENV PATH="/opt/Odin:${PATH}"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install language-specific dependencies
+RUN .codecrafters/compile.sh

--- a/solutions/odin/01-jm1/code/README.md
+++ b/solutions/odin/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin` installed locally
+1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.odin`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/odin/01-jm1/code/codecrafters.yml
+++ b/solutions/odin/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.7
-buildpack: odin-2025.7
+# Available versions: odin-2026.4
+buildpack: odin-2026.4

--- a/solutions/odin/02-rg2/code/README.md
+++ b/solutions/odin/02-rg2/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin` installed locally
+1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.odin`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/odin/02-rg2/code/codecrafters.yml
+++ b/solutions/odin/02-rg2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.7
-buildpack: odin-2025.7
+# Available versions: odin-2026.4
+buildpack: odin-2026.4

--- a/starter_templates/odin/config.yml
+++ b/starter_templates/odin/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: odin
+  required_executable: odin (dev-2026-04)
   user_editable_file: src/main.odin


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrades the Odin toolchain/buildpack version used to compile and run submissions, which can introduce compiler/runtime incompatibilities for existing starter/solution code. Change is mostly configuration and Docker image additions, but impacts the execution environment.
> 
> **Overview**
> Updates Odin Redis starter + sample solutions to target **Odin `dev-2026-04`** by switching `codecrafters.yml` buildpacks from `odin-2025.7` to `odin-2026.4` and adjusting README instructions to match.
> 
> Adds new Docker images for `odin-2026.3` and `odin-2026.4`, and updates `starter_templates/odin/config.yml` to require `odin (dev-2026-04)` locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11143a000810e50ab0f45bd239041d1b654cc114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->