### PR TITLE
Update alpha tester usernames for Swift 

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -38,7 +38,7 @@ languages:
   - slug: "scala"
   - slug: "swift"
     release_status: "alpha"
-    alpha_tester_usernames: ["JWShroyer", "defmacro-jam"]
+    alpha_tester_usernames: ["JWShroyer", "defmacro-jam", "thibault-ml"]
   - slug: "zig"
 
 marketing:
@@ -176,7 +176,7 @@ extensions:
 
       [redis-persistence]: https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/
       [rdb-file-format]: https://github.com/sripathikrishnan/redis-rdb-tools/blob/548b11ec3c81a603f5b321228d07a61a0b940159/docs/RDB_File_Format.textile
-    
+
   - slug: "persistence-aof"
     name: "AOF Persistence"
     description_markdown: |
@@ -380,7 +380,7 @@ stages:
     difficulty: medium
     marketing_md: |
       In this stage, you'll add support for reading values that have an expiry set.
-    
+
   # AOF Persistence
 
   - slug: "uj3"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change: updates the Swift `alpha_tester_usernames` list and adjusts a couple of blank lines in `course-definition.yml` with no runtime impact.
> 
> **Overview**
> Updates `course-definition.yml` to include an additional Swift alpha tester username (`thibault-ml`).
> 
> Also cleans up minor formatting (blank lines) around the persistence extension/stage sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 280bcc5827b0060b8675e54c8030644ef021097b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->