### PR TITLE
Clarify the `REPLCONF` command description in replication-06-eh4

### DIFF
--- a/stage_descriptions/replication-06-eh4.md
+++ b/stage_descriptions/replication-06-eh4.md
@@ -12,7 +12,7 @@ For this stage, you'll handle the second step of this process.
 
 ### The `REPLCONF` Command
 
-The `REPLCONF` command is used to configure a connected replica. After receiving a response to `PING`, the replica sends two `REPLCONF` commands to the master:
+The `REPLCONF` command is used to configure a connected replica. After receiving a response to `PING`, the replica sends two `REPLCONF` commands one-by-one, waiting for a response after each.
 
 1. `REPLCONF listening-port <PORT>`: This tells the master which port the replica is listening on. This value is used for [monitoring and logging](https://github.com/redis/redis/blob/90178712f6eccf1e5b61daa677c5c103114bda3a/src/replication.c#L107-L130), not for replication itself.
 2. `REPLCONF capa psync2`: This notifies the master of the replica's capabilities.
@@ -30,7 +30,7 @@ Both commands should be sent as RESP arrays, so the exact bytes will look someth
 *3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n
 ```
 
-For both commands, the master will respond with `+OK\r\n`. That's the string `OK` encoded as a [simple string](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings).
+For both commands, the master will respond with `+OK\r\n`. That's the string `OK` encoded as a [simple string](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings). The replica should wait for this response before sending the next command.
 
 ### Tests
 


### PR DESCRIPTION
Context:

https://secure.helpscout.net/conversation/3294822595/12679?viewId=8414074

<img width="1852" height="790" alt="image" src="https://github.com/user-attachments/assets/ea40a912-6cfe-4161-8c93-7cf542e3756e" />

Thanks to @0xdef4 for highlighting the issue!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies command/response ordering; no runtime code paths are modified.
> 
> **Overview**
> Clarifies the replication stage instructions to state that the replica must send the two `REPLCONF` commands sequentially and **wait for the master’s `+OK` response after each** before sending the next command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b239087f123152bf589bdc007ab17443d06d9d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->