### PR TITLE
Update log output in Zig starter templates to include a newline 

### DIFF
--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -4,7 +4,7 @@ pub fn main(init: std.process.Init) !void {
     const io = init.io;
 
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!");
+    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!\n");
 
     // Uncomment the code below to pass the first stage
     //

--- a/solutions/zig/01-jm1/diff/src/main.zig.diff
+++ b/solutions/zig/01-jm1/diff/src/main.zig.diff
@@ -5,7 +5,7 @@
      const io = init.io;
 
 -    // You can use print statements as follows for debugging, they'll be visible when running tests.
--    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!");
+-    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!\n");
 +    const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 6379);
 
 -    // Uncomment the code below to pass the first stage

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -4,7 +4,7 @@ pub fn main(init: std.process.Init) !void {
     const io = init.io;
 
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!");
+    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!\n");
 
     // Uncomment the code below to pass the first stage
     //


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: template-only string tweak plus an updated solution patch file; no production logic changes beyond formatting of starter output.
> 
> **Overview**
> Updates the Zig starter (`starter_templates/zig` and generated `compiled_starters/zig`) to print the initial stderr debug message with a trailing newline.
> 
> Adjusts the stage `01-jm1` Zig `main.zig.diff` patch to align with the updated starter baseline (removing the starter log/comment block and applying the networking/accept logic changes on top of it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e58f2b4d2254bb45a5f6dfa9e2bc202d28207cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->