### PR TITLE
CC-2159: Replace git commands in READMEs as cc submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/clojure/README.md
+++ b/compiled_starters/clojure/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/redis/core.clj`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `clj` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/redis/core.clj`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/crystal/README.md
+++ b/compiled_starters/crystal/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.cr`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `crystal (1.1.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.cr`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (10.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `lib/main.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/haskell/README.md
+++ b/compiled_starters/haskell/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/Main.hs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (23.18)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -13,12 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -13,12 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/ocaml/README.md
+++ b/compiled_starters/ocaml/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.ml`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dune` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.ml`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.odin`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.odin`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.php`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,8 +29,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Troubleshooting
 

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -14,11 +14,10 @@ event loops, the Redis protocol and more.
 
 The entry point for your Redis implementation is in
 `src/main/scala/codecrafters_redis/App.scala`. Study and uncomment the relevant
-code, and push your changes to pass the first stage:
+code, then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/scala/codecrafters_redis/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/swift/README.md
+++ b/compiled_starters/swift/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `Sources/main.swift`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `swift (>=6.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `Sources/main.swift`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/c/01-jm1/code/README.md
+++ b/solutions/c/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/c/02-rg2/code/README.md
+++ b/solutions/c/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/c/03-wy1/code/README.md
+++ b/solutions/c/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/clojure/01-jm1/code/README.md
+++ b/solutions/clojure/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/redis/core.clj`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `clj` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/redis/core.clj`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/clojure/02-rg2/code/README.md
+++ b/solutions/clojure/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/redis/core.clj`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `clj` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/redis/core.clj`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/clojure/03-wy1/code/README.md
+++ b/solutions/clojure/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/redis/core.clj`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `clj` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/redis/core.clj`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/cpp/01-jm1/code/README.md
+++ b/solutions/cpp/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/cpp/02-rg2/code/README.md
+++ b/solutions/cpp/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/cpp/03-wy1/code/README.md
+++ b/solutions/cpp/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/crystal/01-jm1/code/README.md
+++ b/solutions/crystal/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.cr`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `crystal (1.1.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.cr`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/crystal/02-rg2/code/README.md
+++ b/solutions/crystal/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.cr`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `crystal (1.1.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.cr`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/crystal/03-wy1/code/README.md
+++ b/solutions/crystal/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.cr`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `crystal (1.1.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.cr`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/csharp/01-jm1/code/README.md
+++ b/solutions/csharp/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (10.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/csharp/02-rg2/code/README.md
+++ b/solutions/csharp/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (10.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/csharp/03-wy1/code/README.md
+++ b/solutions/csharp/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (10.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/elixir/01-jm1/code/README.md
+++ b/solutions/elixir/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `lib/main.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/elixir/02-rg2/code/README.md
+++ b/solutions/elixir/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `lib/main.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/elixir/03-wy1/code/README.md
+++ b/solutions/elixir/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `lib/main.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/gleam/01-jm1/code/README.md
+++ b/solutions/gleam/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/gleam/02-rg2/code/README.md
+++ b/solutions/gleam/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/go/01-jm1/code/README.md
+++ b/solutions/go/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/go/02-rg2/code/README.md
+++ b/solutions/go/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/go/03-wy1/code/README.md
+++ b/solutions/go/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/haskell/01-jm1/code/README.md
+++ b/solutions/haskell/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/Main.hs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (23.18)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/haskell/02-rg2/code/README.md
+++ b/solutions/haskell/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/Main.hs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (23.18)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/haskell/03-wy1/code/README.md
+++ b/solutions/haskell/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/Main.hs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (23.18)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/java/01-jm1/code/README.md
+++ b/solutions/java/01-jm1/code/README.md
@@ -13,12 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/java/02-rg2/code/README.md
+++ b/solutions/java/02-rg2/code/README.md
@@ -13,12 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/java/03-wy1/code/README.md
+++ b/solutions/java/03-wy1/code/README.md
@@ -13,12 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/javascript/01-jm1/code/README.md
+++ b/solutions/javascript/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/javascript/02-rg2/code/README.md
+++ b/solutions/javascript/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/kotlin/01-jm1/code/README.md
+++ b/solutions/kotlin/01-jm1/code/README.md
@@ -13,12 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/kotlin/02-rg2/code/README.md
+++ b/solutions/kotlin/02-rg2/code/README.md
@@ -13,12 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/kotlin/03-wy1/code/README.md
+++ b/solutions/kotlin/03-wy1/code/README.md
@@ -13,12 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/ocaml/01-jm1/code/README.md
+++ b/solutions/ocaml/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.ml`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dune` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.ml`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/ocaml/02-rg2/code/README.md
+++ b/solutions/ocaml/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.ml`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dune` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.ml`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/ocaml/03-wy1/code/README.md
+++ b/solutions/ocaml/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.ml`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dune` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.ml`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/odin/01-jm1/code/README.md
+++ b/solutions/odin/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.odin`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.odin`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/odin/02-rg2/code/README.md
+++ b/solutions/odin/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.odin`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.odin`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/odin/03-wy1/code/README.md
+++ b/solutions/odin/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.odin`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.odin`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/php/01-jm1/code/README.md
+++ b/solutions/php/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.php`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/php/02-rg2/code/README.md
+++ b/solutions/php/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.php`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/php/03-wy1/code/README.md
+++ b/solutions/php/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.php`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/python/01-jm1/code/README.md
+++ b/solutions/python/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,8 +29,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Troubleshooting
 

--- a/solutions/python/02-rg2/code/README.md
+++ b/solutions/python/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,8 +29,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Troubleshooting
 

--- a/solutions/python/03-wy1/code/README.md
+++ b/solutions/python/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,8 +29,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Troubleshooting
 

--- a/solutions/ruby/01-jm1/code/README.md
+++ b/solutions/ruby/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/ruby/02-rg2/code/README.md
+++ b/solutions/ruby/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/ruby/03-wy1/code/README.md
+++ b/solutions/ruby/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/rust/01-jm1/code/README.md
+++ b/solutions/rust/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/rust/02-rg2/code/README.md
+++ b/solutions/rust/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/rust/03-wy1/code/README.md
+++ b/solutions/rust/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/scala/01-jm1/code/README.md
+++ b/solutions/scala/01-jm1/code/README.md
@@ -14,11 +14,10 @@ event loops, the Redis protocol and more.
 
 The entry point for your Redis implementation is in
 `src/main/scala/codecrafters_redis/App.scala`. Study and uncomment the relevant
-code, and push your changes to pass the first stage:
+code, then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/scala/codecrafters_redis/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/scala/02-rg2/code/README.md
+++ b/solutions/scala/02-rg2/code/README.md
@@ -14,11 +14,10 @@ event loops, the Redis protocol and more.
 
 The entry point for your Redis implementation is in
 `src/main/scala/codecrafters_redis/App.scala`. Study and uncomment the relevant
-code, and push your changes to pass the first stage:
+code, then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/scala/codecrafters_redis/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/scala/03-wy1/code/README.md
+++ b/solutions/scala/03-wy1/code/README.md
@@ -14,11 +14,10 @@ event loops, the Redis protocol and more.
 
 The entry point for your Redis implementation is in
 `src/main/scala/codecrafters_redis/App.scala`. Study and uncomment the relevant
-code, and push your changes to pass the first stage:
+code, then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -30,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main/scala/codecrafters_redis/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/swift/01-jm1/code/README.md
+++ b/solutions/swift/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `Sources/main.swift`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `swift (>=6.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `Sources/main.swift`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/swift/02-rg2/code/README.md
+++ b/solutions/swift/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `Sources/main.swift`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `swift (>=6.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `Sources/main.swift`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/swift/03-wy1/code/README.md
+++ b/solutions/swift/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `Sources/main.swift`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `swift (>=6.0)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `Sources/main.swift`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/typescript/01-jm1/code/README.md
+++ b/solutions/typescript/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/typescript/02-rg2/code/README.md
+++ b/solutions/typescript/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/zig/01-jm1/code/README.md
+++ b/solutions/zig/01-jm1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/zig/02-rg2/code/README.md
+++ b/solutions/zig/02-rg2/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/zig/03-wy1/code/README.md
+++ b/solutions/zig/03-wy1/code/README.md
@@ -13,11 +13,11 @@ event loops, the Redis protocol and more.
 # Passing the first stage
 
 The entry point for your Redis implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -29,5 +29,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -12,12 +12,10 @@ event loops, the Redis protocol and more.
 
 # Passing the first stage
 
-The entry point for your Redis implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, and
-push your changes to pass the first stage:
+The entry point for your Redis implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!
@@ -31,8 +29,7 @@ Note: This section is for stages 2 and beyond.
    `{{ user_editable_file }}`.{{# language_is_rust }} This command compiles your
    Rust project, so it might be slow the first time you run it. Subsequent runs
    will be fast.{{/ language_is_rust}}
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test output will be streamed to your terminal.
 
 {{#language_is_python}}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates submission instructions; no runtime or build logic is modified.
> 
> **Overview**
> **Submission instructions have been standardized across templates and language starters.** READMEs in `compiled_starters/*`, `solutions/*`, and `starter_templates/all` now direct users to run `codecrafters submit` (and clarify this runs tests on CodeCrafters servers) instead of `git commit`/`git push`.
> 
> Minor wording/line-wrapping tweaks accompany this to keep the “Passing the first stage” and “Stage 2 & beyond” sections consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa41dd4df08e782e4a3ddbf514c22faa5f147ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->