### PR TITLE
CC-2274: Upgrade Gleam to v0.16

### DIFF
--- a/compiled_starters/gleam/.codecrafters/compile.sh
+++ b/compiled_starters/gleam/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/compiled_starters/gleam/.codecrafters/run.sh
+++ b/compiled_starters/gleam/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/compiled_starters/gleam/.gitignore
+++ b/compiled_starters/gleam/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/compiled_starters/gleam/codecrafters.yml
+++ b/compiled_starters/gleam/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/compiled_starters/gleam/gleam.toml
+++ b/compiled_starters/gleam/gleam.toml
@@ -1,4 +1,4 @@
-name = "codecrafters_redis"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
@@ -11,4 +11,5 @@ gleam_otp = "~> 0.10"
 glisten = "~> 2.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/compiled_starters/gleam/manifest.toml
+++ b/compiled_starters/gleam/manifest.toml
@@ -2,16 +2,23 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleescript", version = "1.4.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "8CDDD29F91064E69950A91A40061785F10275ADB70A0520075591F61A724C455" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
   { name = "glisten", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "CF3A9383E9BA4A8CBAF2F7B799716290D02F2AC34E7A77556B49376B662B9314" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
 ]
 
 [requirements]
 gleam_erlang = { version = "~> 0.25" }
 gleam_otp = { version = "~> 0.10" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glisten = { version = "~> 2.0"}
+glisten = { version = "~> 2.0" }

--- a/compiled_starters/gleam/your_program.sh
+++ b/compiled_starters/gleam/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/dockerfiles/gleam-1.16.Dockerfile
+++ b/dockerfiles/gleam-1.16.Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine
+
+# Rebuild if gleam.toml or manifest.toml change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="gleam.toml,manifest.toml"
+
+RUN apk add --no-cache \
+    build-base~=0.5
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Force deps to be downloaded
+RUN gleam build
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv build /app-cached/build

--- a/solutions/gleam/01-jm1/code/.codecrafters/compile.sh
+++ b/solutions/gleam/01-jm1/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/01-jm1/code/.codecrafters/run.sh
+++ b/solutions/gleam/01-jm1/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/01-jm1/code/.gitignore
+++ b/solutions/gleam/01-jm1/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/01-jm1/code/codecrafters.yml
+++ b/solutions/gleam/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/01-jm1/code/gleam.toml
+++ b/solutions/gleam/01-jm1/code/gleam.toml
@@ -1,4 +1,4 @@
-name = "codecrafters_redis"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
@@ -11,4 +11,5 @@ gleam_otp = "~> 0.10"
 glisten = "~> 2.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/01-jm1/code/manifest.toml
+++ b/solutions/gleam/01-jm1/code/manifest.toml
@@ -2,16 +2,23 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleescript", version = "1.4.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "8CDDD29F91064E69950A91A40061785F10275ADB70A0520075591F61A724C455" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
   { name = "glisten", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "CF3A9383E9BA4A8CBAF2F7B799716290D02F2AC34E7A77556B49376B662B9314" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
 ]
 
 [requirements]
 gleam_erlang = { version = "~> 0.25" }
 gleam_otp = { version = "~> 0.10" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glisten = { version = "~> 2.0"}
+glisten = { version = "~> 2.0" }

--- a/solutions/gleam/01-jm1/code/your_program.sh
+++ b/solutions/gleam/01-jm1/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/02-rg2/code/.codecrafters/compile.sh
+++ b/solutions/gleam/02-rg2/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/02-rg2/code/.codecrafters/run.sh
+++ b/solutions/gleam/02-rg2/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/02-rg2/code/.gitignore
+++ b/solutions/gleam/02-rg2/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/02-rg2/code/codecrafters.yml
+++ b/solutions/gleam/02-rg2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/02-rg2/code/gleam.toml
+++ b/solutions/gleam/02-rg2/code/gleam.toml
@@ -1,4 +1,4 @@
-name = "codecrafters_redis"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
@@ -11,4 +11,5 @@ gleam_otp = "~> 0.10"
 glisten = "~> 2.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/02-rg2/code/manifest.toml
+++ b/solutions/gleam/02-rg2/code/manifest.toml
@@ -2,16 +2,23 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleescript", version = "1.4.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "8CDDD29F91064E69950A91A40061785F10275ADB70A0520075591F61A724C455" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
   { name = "glisten", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "CF3A9383E9BA4A8CBAF2F7B799716290D02F2AC34E7A77556B49376B662B9314" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
 ]
 
 [requirements]
 gleam_erlang = { version = "~> 0.25" }
 gleam_otp = { version = "~> 0.10" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glisten = { version = "~> 2.0"}
+glisten = { version = "~> 2.0" }

--- a/solutions/gleam/02-rg2/code/your_program.sh
+++ b/solutions/gleam/02-rg2/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/starter_templates/gleam/code/.codecrafters/compile.sh
+++ b/starter_templates/gleam/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/starter_templates/gleam/code/.codecrafters/run.sh
+++ b/starter_templates/gleam/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/starter_templates/gleam/code/.gitignore
+++ b/starter_templates/gleam/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/starter_templates/gleam/code/gleam.toml
+++ b/starter_templates/gleam/code/gleam.toml
@@ -1,4 +1,4 @@
-name = "codecrafters_redis"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
@@ -11,4 +11,5 @@ gleam_otp = "~> 0.10"
 glisten = "~> 2.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/starter_templates/gleam/code/manifest.toml
+++ b/starter_templates/gleam/code/manifest.toml
@@ -2,16 +2,23 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
   { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleescript", version = "1.4.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "8CDDD29F91064E69950A91A40061785F10275ADB70A0520075591F61A724C455" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
   { name = "glisten", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "CF3A9383E9BA4A8CBAF2F7B799716290D02F2AC34E7A77556B49376B662B9314" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
 ]
 
 [requirements]
 gleam_erlang = { version = "~> 0.25" }
 gleam_otp = { version = "~> 0.10" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glisten = { version = "~> 2.0"}
+glisten = { version = "~> 2.0" }


### PR DESCRIPTION
CC-2274: Upgrade Gleam to v0.16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Gleam toolchain version and the CodeCrafters build/run pipeline to generate and execute a compiled `main` binary, which could break builds or runtime invocation if the binary isn’t produced correctly.
> 
> **Overview**
> Upgrades Gleam from `gleam-1.14` to `gleam-1.16` and adds a `gleam-1.16` Docker image for the buildpack.
> 
> Updates Gleam starters/templates/solutions to compile a standalone `main` executable by running `gleam run -m gleescript` during compile, then runs via `./main` instead of `gleam run`.
> 
> Renames the project to `name = "main"`, adds `gleescript` as a dev dependency (with updated `manifest.toml`), and ignores the generated `main` binary in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7b6b0ef40f6836b13276b21fb01875863666e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->