### PR TITLE
Add incremental build support for Swift + bump to Swift 6.3

### DIFF
--- a/compiled_starters/swift/.codecrafters/compile.sh
+++ b/compiled_starters/swift/.codecrafters/compile.sh
@@ -8,4 +8,15 @@
 
 set -e # Exit on failure
 
+# Restore the mtimes of all source files before building. This works around some
+# container backends that truncate mtimes, causing Swift's llbuild to rebuild
+# everything (no incremental builds).
+#
+# See the documentation in `restore_mtimes.sh` for more details.
+#
+# If the snapshot restore failed, skip the restore step and proceed with the
+# build anyway. This can happen if the snapshot file is missing (e.g. local
+# development).
+.codecrafters/restore_mtimes.sh || true
+
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/compiled_starters/swift/.codecrafters/restore_mtimes.sh
+++ b/compiled_starters/swift/.codecrafters/restore_mtimes.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Restore mtimes before building.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+IN="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+if [[ ! -f "$IN" ]]; then
+  echo "Skipping restore: snapshot file not found: $IN" >&2
+  exit 1
+fi
+
+SECONDS=0
+
+# The number of files whose mtimes were successfully restored.
+restored=0
+# The number of files that were missing.
+missing=0
+# The number of files that failed to restore for some reason (e.g. permissions).
+failed=0
+
+# The format is intentionally kept simple for easy parsing.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+while \
+  IFS= read -r -d '' path && \
+  IFS= read -r -d '' mtime_seconds && \
+  IFS= read -r -d '' mtime_nanoseconds
+do
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    missing=$((missing + 1))
+    continue
+  fi
+
+  timestamp="@${mtime_seconds}.${mtime_nanoseconds}"
+
+  # Use -h so that on symlinks, `touch` restores the symlink's own mtime rather
+  # than the target's mtime.
+  if touch -h -m -d "$timestamp" -- "$path"; then
+    restored=$((restored + 1))
+  else
+    failed=$((failed + 1))
+  fi
+done < "$IN"
+
+elapsed="$SECONDS"
+
+printf 'Restored mtimes: restored=%s missing=%s failed=%s time_taken=%ss\n' \
+  "$restored" "$missing" "$failed" "$elapsed"
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi

--- a/compiled_starters/swift/.codecrafters/snapshot_mtimes.sh
+++ b/compiled_starters/swift/.codecrafters/snapshot_mtimes.sh
@@ -85,11 +85,12 @@ for root in "${ROOTS[@]}"; do
     continue
   fi
 
-  # -P means do not follow symlinks.
-  # -print0 includes hidden files automatically and is safe for unusual paths.
+  # `-P` means do not follow symlinks.
+  # `-type d -name '.git*' -prune` skips .git and .github directories which we don't need to snapshot.
+  # `-print0` includes hidden files automatically and is safe for unusual paths.
   while IFS= read -r -d '' path; do
     save_one_path "$path"
-  done < <(find -P "$root" -print0)
+  done < <(find -P "$root" -type d -name '.git*' -prune -o -print0)
 done
 
 mv "$tmp_out" "$OUT"

--- a/compiled_starters/swift/.codecrafters/snapshot_mtimes.sh
+++ b/compiled_starters/swift/.codecrafters/snapshot_mtimes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Snapshot files' mtimes after building, before creating the image.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+#
+# This script captures the mtimes of all source and build files into a snapshot
+# file, which is then included in the image. The companuin `restore_mtimes.sh`
+# script can read this snapshot file and restore the mtimes before the next
+# build.
+#
+# The format is intentionally kept simple for easy parsing in the restore script.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+OUT="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+ROOTS=(
+  "/app"
+  "/tmp/codecrafters-build-redis-swift"
+)
+
+tmp_out="${OUT}.tmp"
+# Truncate the output file at the start. This ensures we don't accidentally
+# append to an old snapshot if something goes wrong during this script.
+: > "$tmp_out"
+
+extract_nsec_from_stat_y() {
+  # Input example from GNU stat %y:
+  #   2026-04-26 22:40:35.123456789 +0000
+  #
+  # Output:
+  #   123456789
+  local stat_y="$1"
+  local frac
+
+  # Extract the nanoseconds part using a regex. Otherwise, use 0.
+  if [[ "$stat_y" =~ :[0-9]{2}\.([0-9]+)[[:space:]] ]]; then
+    frac="${BASH_REMATCH[1]}"
+  else
+    frac="0"
+  fi
+
+  # Right-pad/truncate to exactly 9 digits, so this is a nanosecond field.
+  frac="${frac}000000000"
+  printf '%s\n' "${frac:0:9}"
+}
+
+save_one_path() {
+  local path="$1"
+  local seconds
+  local stat_y
+  local nanoseconds
+
+  # GNU stat default behavior is suitable here: it reports the path itself,
+  # not the symlink target, unless -L is used.
+  seconds="$(stat -c '%Y' -- "$path")"
+  stat_y="$(stat -c '%y' -- "$path")"
+  nanoseconds="$(extract_nsec_from_stat_y "$stat_y")"
+
+  # Record format:
+  #   path NUL seconds NUL nanoseconds NUL
+  printf '%s\0%s\0%s\0' "$path" "$seconds" "$nanoseconds" >> "$tmp_out"
+}
+
+for root in "${ROOTS[@]}"; do
+  if [[ ! -e "$root" && ! -L "$root" ]]; then
+    continue
+  fi
+
+  # -P means do not follow symlinks.
+  # -print0 includes hidden files automatically and is safe for unusual paths.
+  while IFS= read -r -d '' path; do
+    save_one_path "$path"
+  done < <(find -P "$root" -print0)
+done
+
+mv "$tmp_out" "$OUT"
+
+printf 'Created mtimes snapshot at %s\n' "$OUT"

--- a/compiled_starters/swift/Package.swift
+++ b/compiled_starters/swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/compiled_starters/swift/README.md
+++ b/compiled_starters/swift/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `swift (>=6.0)` installed locally
+1. Ensure you have `swift (>=6.3)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `Sources/main.swift`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/compiled_starters/swift/codecrafters.yml
+++ b/compiled_starters/swift/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Swift version used to run your code
 # on Codecrafters.
 #
-# Available versions: swift-6.0.1
-buildpack: swift-6.0.1
+# Available versions: swift-6.3
+buildpack: swift-6.3

--- a/compiled_starters/swift/your_program.sh
+++ b/compiled_starters/swift/your_program.sh
@@ -14,6 +14,7 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  .codecrafters/restore_mtimes.sh || true
   swift build -c release --build-path /tmp/codecrafters-build-redis-swift
 )
 

--- a/dockerfiles/swift-6.3.Dockerfile
+++ b/dockerfiles/swift-6.3.Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM swift:6.3-noble
+
+# Ensures the container is re-built if Package.swift changes
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Package.swift,Package.resolved"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+RUN .codecrafters/compile.sh
+
+# Snapshot the mtimes of all source files after a successful build. Their mtimes
+# will be restored before the next build in the container. This works around
+# some container backends that truncate mtimes, causing Swift's llbuild to
+# rebuild everything (no incremental builds).
+#
+# See the documentation in `snapshot_mtimes.sh` for more details.
+RUN .codecrafters/snapshot_mtimes.sh

--- a/solutions/swift/01-jm1/code/.codecrafters/compile.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/compile.sh
@@ -8,4 +8,15 @@
 
 set -e # Exit on failure
 
+# Restore the mtimes of all source files before building. This works around some
+# container backends that truncate mtimes, causing Swift's llbuild to rebuild
+# everything (no incremental builds).
+#
+# See the documentation in `restore_mtimes.sh` for more details.
+#
+# If the snapshot restore failed, skip the restore step and proceed with the
+# build anyway. This can happen if the snapshot file is missing (e.g. local
+# development).
+.codecrafters/restore_mtimes.sh || true
+
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/solutions/swift/01-jm1/code/.codecrafters/restore_mtimes.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/restore_mtimes.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Restore mtimes before building.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+IN="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+if [[ ! -f "$IN" ]]; then
+  echo "Skipping restore: snapshot file not found: $IN" >&2
+  exit 1
+fi
+
+SECONDS=0
+
+# The number of files whose mtimes were successfully restored.
+restored=0
+# The number of files that were missing.
+missing=0
+# The number of files that failed to restore for some reason (e.g. permissions).
+failed=0
+
+# The format is intentionally kept simple for easy parsing.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+while \
+  IFS= read -r -d '' path && \
+  IFS= read -r -d '' mtime_seconds && \
+  IFS= read -r -d '' mtime_nanoseconds
+do
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    missing=$((missing + 1))
+    continue
+  fi
+
+  timestamp="@${mtime_seconds}.${mtime_nanoseconds}"
+
+  # Use -h so that on symlinks, `touch` restores the symlink's own mtime rather
+  # than the target's mtime.
+  if touch -h -m -d "$timestamp" -- "$path"; then
+    restored=$((restored + 1))
+  else
+    failed=$((failed + 1))
+  fi
+done < "$IN"
+
+elapsed="$SECONDS"
+
+printf 'Restored mtimes: restored=%s missing=%s failed=%s time_taken=%ss\n' \
+  "$restored" "$missing" "$failed" "$elapsed"
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi

--- a/solutions/swift/01-jm1/code/.codecrafters/snapshot_mtimes.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/snapshot_mtimes.sh
@@ -85,11 +85,12 @@ for root in "${ROOTS[@]}"; do
     continue
   fi
 
-  # -P means do not follow symlinks.
-  # -print0 includes hidden files automatically and is safe for unusual paths.
+  # `-P` means do not follow symlinks.
+  # `-type d -name '.git*' -prune` skips .git and .github directories which we don't need to snapshot.
+  # `-print0` includes hidden files automatically and is safe for unusual paths.
   while IFS= read -r -d '' path; do
     save_one_path "$path"
-  done < <(find -P "$root" -print0)
+  done < <(find -P "$root" -type d -name '.git*' -prune -o -print0)
 done
 
 mv "$tmp_out" "$OUT"

--- a/solutions/swift/01-jm1/code/.codecrafters/snapshot_mtimes.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/snapshot_mtimes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Snapshot files' mtimes after building, before creating the image.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+#
+# This script captures the mtimes of all source and build files into a snapshot
+# file, which is then included in the image. The companuin `restore_mtimes.sh`
+# script can read this snapshot file and restore the mtimes before the next
+# build.
+#
+# The format is intentionally kept simple for easy parsing in the restore script.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+OUT="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+ROOTS=(
+  "/app"
+  "/tmp/codecrafters-build-redis-swift"
+)
+
+tmp_out="${OUT}.tmp"
+# Truncate the output file at the start. This ensures we don't accidentally
+# append to an old snapshot if something goes wrong during this script.
+: > "$tmp_out"
+
+extract_nsec_from_stat_y() {
+  # Input example from GNU stat %y:
+  #   2026-04-26 22:40:35.123456789 +0000
+  #
+  # Output:
+  #   123456789
+  local stat_y="$1"
+  local frac
+
+  # Extract the nanoseconds part using a regex. Otherwise, use 0.
+  if [[ "$stat_y" =~ :[0-9]{2}\.([0-9]+)[[:space:]] ]]; then
+    frac="${BASH_REMATCH[1]}"
+  else
+    frac="0"
+  fi
+
+  # Right-pad/truncate to exactly 9 digits, so this is a nanosecond field.
+  frac="${frac}000000000"
+  printf '%s\n' "${frac:0:9}"
+}
+
+save_one_path() {
+  local path="$1"
+  local seconds
+  local stat_y
+  local nanoseconds
+
+  # GNU stat default behavior is suitable here: it reports the path itself,
+  # not the symlink target, unless -L is used.
+  seconds="$(stat -c '%Y' -- "$path")"
+  stat_y="$(stat -c '%y' -- "$path")"
+  nanoseconds="$(extract_nsec_from_stat_y "$stat_y")"
+
+  # Record format:
+  #   path NUL seconds NUL nanoseconds NUL
+  printf '%s\0%s\0%s\0' "$path" "$seconds" "$nanoseconds" >> "$tmp_out"
+}
+
+for root in "${ROOTS[@]}"; do
+  if [[ ! -e "$root" && ! -L "$root" ]]; then
+    continue
+  fi
+
+  # -P means do not follow symlinks.
+  # -print0 includes hidden files automatically and is safe for unusual paths.
+  while IFS= read -r -d '' path; do
+    save_one_path "$path"
+  done < <(find -P "$root" -print0)
+done
+
+mv "$tmp_out" "$OUT"
+
+printf 'Created mtimes snapshot at %s\n' "$OUT"

--- a/solutions/swift/01-jm1/code/Package.swift
+++ b/solutions/swift/01-jm1/code/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/solutions/swift/01-jm1/code/README.md
+++ b/solutions/swift/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `swift (>=6.0)` installed locally
+1. Ensure you have `swift (>=6.3)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `Sources/main.swift`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/solutions/swift/01-jm1/code/codecrafters.yml
+++ b/solutions/swift/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Swift version used to run your code
 # on Codecrafters.
 #
-# Available versions: swift-6.0.1
-buildpack: swift-6.0.1
+# Available versions: swift-6.3
+buildpack: swift-6.3

--- a/solutions/swift/01-jm1/code/your_program.sh
+++ b/solutions/swift/01-jm1/code/your_program.sh
@@ -14,6 +14,7 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  .codecrafters/restore_mtimes.sh || true
   swift build -c release --build-path /tmp/codecrafters-build-redis-swift
 )
 

--- a/solutions/swift/02-rg2/code/.codecrafters/compile.sh
+++ b/solutions/swift/02-rg2/code/.codecrafters/compile.sh
@@ -8,4 +8,15 @@
 
 set -e # Exit on failure
 
+# Restore the mtimes of all source files before building. This works around some
+# container backends that truncate mtimes, causing Swift's llbuild to rebuild
+# everything (no incremental builds).
+#
+# See the documentation in `restore_mtimes.sh` for more details.
+#
+# If the snapshot restore failed, skip the restore step and proceed with the
+# build anyway. This can happen if the snapshot file is missing (e.g. local
+# development).
+.codecrafters/restore_mtimes.sh || true
+
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/solutions/swift/02-rg2/code/.codecrafters/restore_mtimes.sh
+++ b/solutions/swift/02-rg2/code/.codecrafters/restore_mtimes.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Restore mtimes before building.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+IN="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+if [[ ! -f "$IN" ]]; then
+  echo "Skipping restore: snapshot file not found: $IN" >&2
+  exit 1
+fi
+
+SECONDS=0
+
+# The number of files whose mtimes were successfully restored.
+restored=0
+# The number of files that were missing.
+missing=0
+# The number of files that failed to restore for some reason (e.g. permissions).
+failed=0
+
+# The format is intentionally kept simple for easy parsing.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+while \
+  IFS= read -r -d '' path && \
+  IFS= read -r -d '' mtime_seconds && \
+  IFS= read -r -d '' mtime_nanoseconds
+do
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    missing=$((missing + 1))
+    continue
+  fi
+
+  timestamp="@${mtime_seconds}.${mtime_nanoseconds}"
+
+  # Use -h so that on symlinks, `touch` restores the symlink's own mtime rather
+  # than the target's mtime.
+  if touch -h -m -d "$timestamp" -- "$path"; then
+    restored=$((restored + 1))
+  else
+    failed=$((failed + 1))
+  fi
+done < "$IN"
+
+elapsed="$SECONDS"
+
+printf 'Restored mtimes: restored=%s missing=%s failed=%s time_taken=%ss\n' \
+  "$restored" "$missing" "$failed" "$elapsed"
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi

--- a/solutions/swift/02-rg2/code/.codecrafters/snapshot_mtimes.sh
+++ b/solutions/swift/02-rg2/code/.codecrafters/snapshot_mtimes.sh
@@ -85,11 +85,12 @@ for root in "${ROOTS[@]}"; do
     continue
   fi
 
-  # -P means do not follow symlinks.
-  # -print0 includes hidden files automatically and is safe for unusual paths.
+  # `-P` means do not follow symlinks.
+  # `-type d -name '.git*' -prune` skips .git and .github directories which we don't need to snapshot.
+  # `-print0` includes hidden files automatically and is safe for unusual paths.
   while IFS= read -r -d '' path; do
     save_one_path "$path"
-  done < <(find -P "$root" -print0)
+  done < <(find -P "$root" -type d -name '.git*' -prune -o -print0)
 done
 
 mv "$tmp_out" "$OUT"

--- a/solutions/swift/02-rg2/code/.codecrafters/snapshot_mtimes.sh
+++ b/solutions/swift/02-rg2/code/.codecrafters/snapshot_mtimes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Snapshot files' mtimes after building, before creating the image.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+#
+# This script captures the mtimes of all source and build files into a snapshot
+# file, which is then included in the image. The companuin `restore_mtimes.sh`
+# script can read this snapshot file and restore the mtimes before the next
+# build.
+#
+# The format is intentionally kept simple for easy parsing in the restore script.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+OUT="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+ROOTS=(
+  "/app"
+  "/tmp/codecrafters-build-redis-swift"
+)
+
+tmp_out="${OUT}.tmp"
+# Truncate the output file at the start. This ensures we don't accidentally
+# append to an old snapshot if something goes wrong during this script.
+: > "$tmp_out"
+
+extract_nsec_from_stat_y() {
+  # Input example from GNU stat %y:
+  #   2026-04-26 22:40:35.123456789 +0000
+  #
+  # Output:
+  #   123456789
+  local stat_y="$1"
+  local frac
+
+  # Extract the nanoseconds part using a regex. Otherwise, use 0.
+  if [[ "$stat_y" =~ :[0-9]{2}\.([0-9]+)[[:space:]] ]]; then
+    frac="${BASH_REMATCH[1]}"
+  else
+    frac="0"
+  fi
+
+  # Right-pad/truncate to exactly 9 digits, so this is a nanosecond field.
+  frac="${frac}000000000"
+  printf '%s\n' "${frac:0:9}"
+}
+
+save_one_path() {
+  local path="$1"
+  local seconds
+  local stat_y
+  local nanoseconds
+
+  # GNU stat default behavior is suitable here: it reports the path itself,
+  # not the symlink target, unless -L is used.
+  seconds="$(stat -c '%Y' -- "$path")"
+  stat_y="$(stat -c '%y' -- "$path")"
+  nanoseconds="$(extract_nsec_from_stat_y "$stat_y")"
+
+  # Record format:
+  #   path NUL seconds NUL nanoseconds NUL
+  printf '%s\0%s\0%s\0' "$path" "$seconds" "$nanoseconds" >> "$tmp_out"
+}
+
+for root in "${ROOTS[@]}"; do
+  if [[ ! -e "$root" && ! -L "$root" ]]; then
+    continue
+  fi
+
+  # -P means do not follow symlinks.
+  # -print0 includes hidden files automatically and is safe for unusual paths.
+  while IFS= read -r -d '' path; do
+    save_one_path "$path"
+  done < <(find -P "$root" -print0)
+done
+
+mv "$tmp_out" "$OUT"
+
+printf 'Created mtimes snapshot at %s\n' "$OUT"

--- a/solutions/swift/02-rg2/code/Package.swift
+++ b/solutions/swift/02-rg2/code/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/solutions/swift/02-rg2/code/README.md
+++ b/solutions/swift/02-rg2/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `swift (>=6.0)` installed locally
+1. Ensure you have `swift (>=6.3)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `Sources/main.swift`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/solutions/swift/02-rg2/code/codecrafters.yml
+++ b/solutions/swift/02-rg2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Swift version used to run your code
 # on Codecrafters.
 #
-# Available versions: swift-6.0.1
-buildpack: swift-6.0.1
+# Available versions: swift-6.3
+buildpack: swift-6.3

--- a/solutions/swift/02-rg2/code/your_program.sh
+++ b/solutions/swift/02-rg2/code/your_program.sh
@@ -14,6 +14,7 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  .codecrafters/restore_mtimes.sh || true
   swift build -c release --build-path /tmp/codecrafters-build-redis-swift
 )
 

--- a/solutions/swift/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/swift/03-wy1/code/.codecrafters/compile.sh
@@ -8,4 +8,15 @@
 
 set -e # Exit on failure
 
+# Restore the mtimes of all source files before building. This works around some
+# container backends that truncate mtimes, causing Swift's llbuild to rebuild
+# everything (no incremental builds).
+#
+# See the documentation in `restore_mtimes.sh` for more details.
+#
+# If the snapshot restore failed, skip the restore step and proceed with the
+# build anyway. This can happen if the snapshot file is missing (e.g. local
+# development).
+.codecrafters/restore_mtimes.sh || true
+
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/solutions/swift/03-wy1/code/.codecrafters/restore_mtimes.sh
+++ b/solutions/swift/03-wy1/code/.codecrafters/restore_mtimes.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Restore mtimes before building.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+IN="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+if [[ ! -f "$IN" ]]; then
+  echo "Skipping restore: snapshot file not found: $IN" >&2
+  exit 1
+fi
+
+SECONDS=0
+
+# The number of files whose mtimes were successfully restored.
+restored=0
+# The number of files that were missing.
+missing=0
+# The number of files that failed to restore for some reason (e.g. permissions).
+failed=0
+
+# The format is intentionally kept simple for easy parsing.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+while \
+  IFS= read -r -d '' path && \
+  IFS= read -r -d '' mtime_seconds && \
+  IFS= read -r -d '' mtime_nanoseconds
+do
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    missing=$((missing + 1))
+    continue
+  fi
+
+  timestamp="@${mtime_seconds}.${mtime_nanoseconds}"
+
+  # Use -h so that on symlinks, `touch` restores the symlink's own mtime rather
+  # than the target's mtime.
+  if touch -h -m -d "$timestamp" -- "$path"; then
+    restored=$((restored + 1))
+  else
+    failed=$((failed + 1))
+  fi
+done < "$IN"
+
+elapsed="$SECONDS"
+
+printf 'Restored mtimes: restored=%s missing=%s failed=%s time_taken=%ss\n' \
+  "$restored" "$missing" "$failed" "$elapsed"
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi

--- a/solutions/swift/03-wy1/code/.codecrafters/snapshot_mtimes.sh
+++ b/solutions/swift/03-wy1/code/.codecrafters/snapshot_mtimes.sh
@@ -85,11 +85,12 @@ for root in "${ROOTS[@]}"; do
     continue
   fi
 
-  # -P means do not follow symlinks.
-  # -print0 includes hidden files automatically and is safe for unusual paths.
+  # `-P` means do not follow symlinks.
+  # `-type d -name '.git*' -prune` skips .git and .github directories which we don't need to snapshot.
+  # `-print0` includes hidden files automatically and is safe for unusual paths.
   while IFS= read -r -d '' path; do
     save_one_path "$path"
-  done < <(find -P "$root" -print0)
+  done < <(find -P "$root" -type d -name '.git*' -prune -o -print0)
 done
 
 mv "$tmp_out" "$OUT"

--- a/solutions/swift/03-wy1/code/.codecrafters/snapshot_mtimes.sh
+++ b/solutions/swift/03-wy1/code/.codecrafters/snapshot_mtimes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Snapshot files' mtimes after building, before creating the image.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+#
+# This script captures the mtimes of all source and build files into a snapshot
+# file, which is then included in the image. The companuin `restore_mtimes.sh`
+# script can read this snapshot file and restore the mtimes before the next
+# build.
+#
+# The format is intentionally kept simple for easy parsing in the restore script.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+OUT="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+ROOTS=(
+  "/app"
+  "/tmp/codecrafters-build-redis-swift"
+)
+
+tmp_out="${OUT}.tmp"
+# Truncate the output file at the start. This ensures we don't accidentally
+# append to an old snapshot if something goes wrong during this script.
+: > "$tmp_out"
+
+extract_nsec_from_stat_y() {
+  # Input example from GNU stat %y:
+  #   2026-04-26 22:40:35.123456789 +0000
+  #
+  # Output:
+  #   123456789
+  local stat_y="$1"
+  local frac
+
+  # Extract the nanoseconds part using a regex. Otherwise, use 0.
+  if [[ "$stat_y" =~ :[0-9]{2}\.([0-9]+)[[:space:]] ]]; then
+    frac="${BASH_REMATCH[1]}"
+  else
+    frac="0"
+  fi
+
+  # Right-pad/truncate to exactly 9 digits, so this is a nanosecond field.
+  frac="${frac}000000000"
+  printf '%s\n' "${frac:0:9}"
+}
+
+save_one_path() {
+  local path="$1"
+  local seconds
+  local stat_y
+  local nanoseconds
+
+  # GNU stat default behavior is suitable here: it reports the path itself,
+  # not the symlink target, unless -L is used.
+  seconds="$(stat -c '%Y' -- "$path")"
+  stat_y="$(stat -c '%y' -- "$path")"
+  nanoseconds="$(extract_nsec_from_stat_y "$stat_y")"
+
+  # Record format:
+  #   path NUL seconds NUL nanoseconds NUL
+  printf '%s\0%s\0%s\0' "$path" "$seconds" "$nanoseconds" >> "$tmp_out"
+}
+
+for root in "${ROOTS[@]}"; do
+  if [[ ! -e "$root" && ! -L "$root" ]]; then
+    continue
+  fi
+
+  # -P means do not follow symlinks.
+  # -print0 includes hidden files automatically and is safe for unusual paths.
+  while IFS= read -r -d '' path; do
+    save_one_path "$path"
+  done < <(find -P "$root" -print0)
+done
+
+mv "$tmp_out" "$OUT"
+
+printf 'Created mtimes snapshot at %s\n' "$OUT"

--- a/solutions/swift/03-wy1/code/Package.swift
+++ b/solutions/swift/03-wy1/code/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/solutions/swift/03-wy1/code/README.md
+++ b/solutions/swift/03-wy1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `swift (>=6.0)` installed locally
+1. Ensure you have `swift (>=6.3)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `Sources/main.swift`.
 1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test

--- a/solutions/swift/03-wy1/code/codecrafters.yml
+++ b/solutions/swift/03-wy1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Swift version used to run your code
 # on Codecrafters.
 #
-# Available versions: swift-6.0.1
-buildpack: swift-6.0.1
+# Available versions: swift-6.3
+buildpack: swift-6.3

--- a/solutions/swift/03-wy1/code/your_program.sh
+++ b/solutions/swift/03-wy1/code/your_program.sh
@@ -14,6 +14,7 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  .codecrafters/restore_mtimes.sh || true
   swift build -c release --build-path /tmp/codecrafters-build-redis-swift
 )
 

--- a/starter_templates/swift/code/.codecrafters/compile.sh
+++ b/starter_templates/swift/code/.codecrafters/compile.sh
@@ -8,4 +8,15 @@
 
 set -e # Exit on failure
 
+# Restore the mtimes of all source files before building. This works around some
+# container backends that truncate mtimes, causing Swift's llbuild to rebuild
+# everything (no incremental builds).
+#
+# See the documentation in `restore_mtimes.sh` for more details.
+#
+# If the snapshot restore failed, skip the restore step and proceed with the
+# build anyway. This can happen if the snapshot file is missing (e.g. local
+# development).
+.codecrafters/restore_mtimes.sh || true
+
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift

--- a/starter_templates/swift/code/.codecrafters/restore_mtimes.sh
+++ b/starter_templates/swift/code/.codecrafters/restore_mtimes.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Restore mtimes before building.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+IN="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+if [[ ! -f "$IN" ]]; then
+  echo "Skipping restore: snapshot file not found: $IN" >&2
+  exit 1
+fi
+
+SECONDS=0
+
+# The number of files whose mtimes were successfully restored.
+restored=0
+# The number of files that were missing.
+missing=0
+# The number of files that failed to restore for some reason (e.g. permissions).
+failed=0
+
+# The format is intentionally kept simple for easy parsing.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+while \
+  IFS= read -r -d '' path && \
+  IFS= read -r -d '' mtime_seconds && \
+  IFS= read -r -d '' mtime_nanoseconds
+do
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    missing=$((missing + 1))
+    continue
+  fi
+
+  timestamp="@${mtime_seconds}.${mtime_nanoseconds}"
+
+  # Use -h so that on symlinks, `touch` restores the symlink's own mtime rather
+  # than the target's mtime.
+  if touch -h -m -d "$timestamp" -- "$path"; then
+    restored=$((restored + 1))
+  else
+    failed=$((failed + 1))
+  fi
+done < "$IN"
+
+elapsed="$SECONDS"
+
+printf 'Restored mtimes: restored=%s missing=%s failed=%s time_taken=%ss\n' \
+  "$restored" "$missing" "$failed" "$elapsed"
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi

--- a/starter_templates/swift/code/.codecrafters/snapshot_mtimes.sh
+++ b/starter_templates/swift/code/.codecrafters/snapshot_mtimes.sh
@@ -85,11 +85,12 @@ for root in "${ROOTS[@]}"; do
     continue
   fi
 
-  # -P means do not follow symlinks.
-  # -print0 includes hidden files automatically and is safe for unusual paths.
+  # `-P` means do not follow symlinks.
+  # `-type d -name '.git*' -prune` skips .git and .github directories which we don't need to snapshot.
+  # `-print0` includes hidden files automatically and is safe for unusual paths.
   while IFS= read -r -d '' path; do
     save_one_path "$path"
-  done < <(find -P "$root" -print0)
+  done < <(find -P "$root" -type d -name '.git*' -prune -o -print0)
 done
 
 mv "$tmp_out" "$OUT"

--- a/starter_templates/swift/code/.codecrafters/snapshot_mtimes.sh
+++ b/starter_templates/swift/code/.codecrafters/snapshot_mtimes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Snapshot files' mtimes after building, before creating the image.
+# 
+# This works around a bug where—depending on the container backend—source and
+# build files copied into the image may have the nanoseconds truncated off their
+# mtimes. This creates an inconsistency, when a container uses the image,
+# between the filesystem (no nanoseconds) and what Swift's llbuild recorded
+# (includes nanoseconds). This mismatch of timestamps causes llbuild to think
+# all files have changed since the last build, causing a full rebuild every time
+# (no incremental builds). By snapshotting after the build and before the image
+# is created, the mtimes can be restored before the next build in the container
+# to match what llbuild recorded, thus avoiding unnecessary rebuilds and
+# speeding up the build process.
+#
+# This script captures the mtimes of all source and build files into a snapshot
+# file, which is then included in the image. The companuin `restore_mtimes.sh`
+# script can read this snapshot file and restore the mtimes before the next
+# build.
+#
+# The format is intentionally kept simple for easy parsing in the restore script.
+# Each record is:
+#   path NUL seconds NUL nanoseconds NUL
+# where the timestamp is split into seconds and nanoseconds, to avoid issues
+# with floating point precision and locale-specific decimal separators.
+
+set -euo pipefail
+
+# Use a consistent locale and timezone to ensure consistent timestamp formatting.
+export LC_ALL=C
+export TZ=UTC
+
+OUT="${1:-/tmp/codecrafters-mtimes.snapshot}"
+
+ROOTS=(
+  "/app"
+  "/tmp/codecrafters-build-redis-swift"
+)
+
+tmp_out="${OUT}.tmp"
+# Truncate the output file at the start. This ensures we don't accidentally
+# append to an old snapshot if something goes wrong during this script.
+: > "$tmp_out"
+
+extract_nsec_from_stat_y() {
+  # Input example from GNU stat %y:
+  #   2026-04-26 22:40:35.123456789 +0000
+  #
+  # Output:
+  #   123456789
+  local stat_y="$1"
+  local frac
+
+  # Extract the nanoseconds part using a regex. Otherwise, use 0.
+  if [[ "$stat_y" =~ :[0-9]{2}\.([0-9]+)[[:space:]] ]]; then
+    frac="${BASH_REMATCH[1]}"
+  else
+    frac="0"
+  fi
+
+  # Right-pad/truncate to exactly 9 digits, so this is a nanosecond field.
+  frac="${frac}000000000"
+  printf '%s\n' "${frac:0:9}"
+}
+
+save_one_path() {
+  local path="$1"
+  local seconds
+  local stat_y
+  local nanoseconds
+
+  # GNU stat default behavior is suitable here: it reports the path itself,
+  # not the symlink target, unless -L is used.
+  seconds="$(stat -c '%Y' -- "$path")"
+  stat_y="$(stat -c '%y' -- "$path")"
+  nanoseconds="$(extract_nsec_from_stat_y "$stat_y")"
+
+  # Record format:
+  #   path NUL seconds NUL nanoseconds NUL
+  printf '%s\0%s\0%s\0' "$path" "$seconds" "$nanoseconds" >> "$tmp_out"
+}
+
+for root in "${ROOTS[@]}"; do
+  if [[ ! -e "$root" && ! -L "$root" ]]; then
+    continue
+  fi
+
+  # -P means do not follow symlinks.
+  # -print0 includes hidden files automatically and is safe for unusual paths.
+  while IFS= read -r -d '' path; do
+    save_one_path "$path"
+  done < <(find -P "$root" -print0)
+done
+
+mv "$tmp_out" "$OUT"
+
+printf 'Created mtimes snapshot at %s\n' "$OUT"

--- a/starter_templates/swift/code/Package.swift
+++ b/starter_templates/swift/code/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/starter_templates/swift/config.yml
+++ b/starter_templates/swift/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: "swift (>=6.0)"
+  required_executable: "swift (>=6.3)"
   user_editable_file: Sources/main.swift


### PR DESCRIPTION
This change improves support for Swift projects by allowing incremental build support.

SwiftPM/llbuild stores nanosecond mtimes in `build.db`. In some container backends (e.g. Docker on macOS), files created during docker build keep their mtime with a precision of whole seconds after docker run, losing the nanosecond part. That leaves build.db storing, for example, 19:24:22.104643862, while the runtime filesystem says 19:24:22.000000000. llbuild treats that as a stale build state, and recompiles dependencies. More details about the issue in the forums: https://forum.codecrafters.io/t/swift-language-support/2044/22?u=thibault-ml

This change addresses the issue by snapshotting the mtimes after the build and capturing the snapshot file in the image, and then restoring the mtimes before building.