### PR TITLE
Swift: Use IPv4 + catch errors

### DIFF
--- a/compiled_starters/swift/Sources/main.swift
+++ b/compiled_starters/swift/Sources/main.swift
@@ -23,8 +23,14 @@ let serverBootstrap = ServerBootstrap(group: group)
     }
 
 // Uncomment the code below to pass the first stage
-//// Bind the server to port 6379 and start accepting connections
-//let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
-//print("Server started and listening on \(channel.localAddress!)")
-//try channel.closeFuture.wait()
-//print("Server closed")
+// // Bind the server to port 6379 and start accepting connections
+// do {
+//     let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
+//     print("Server started and listening on \(channel.localAddress!)")
+//     try channel.closeFuture.wait()
+// }
+// catch {
+//     print("Server error: \(error)")
+//     exit(1)
+// }
+// print("Server closed")

--- a/solutions/swift/01-jm1/code/Sources/main.swift
+++ b/solutions/swift/01-jm1/code/Sources/main.swift
@@ -20,7 +20,13 @@ let serverBootstrap = ServerBootstrap(group: group)
     }
 
 // Bind the server to port 6379 and start accepting connections
-let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
-print("Server started and listening on \(channel.localAddress!)")
-try channel.closeFuture.wait()
+do {
+    let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
+    print("Server started and listening on \(channel.localAddress!)")
+    try channel.closeFuture.wait()
+}
+catch {
+    print("Server error: \(error)")
+    exit(1)
+}
 print("Server closed")

--- a/solutions/swift/01-jm1/diff/Sources/main.swift.diff
+++ b/solutions/swift/01-jm1/diff/Sources/main.swift.diff
@@ -1,4 +1,4 @@
-@@ -1,30 +1,26 @@
+@@ -1,36 +1,32 @@
  import Foundation
  import NIO
 
@@ -24,13 +24,25 @@
      }
 
 -// Uncomment the code below to pass the first stage
--//// Bind the server to port 6379 and start accepting connections
--//let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
--//print("Server started and listening on \(channel.localAddress!)")
--//try channel.closeFuture.wait()
--//print("Server closed")
+-// // Bind the server to port 6379 and start accepting connections
+-// do {
+-//     let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
+-//     print("Server started and listening on \(channel.localAddress!)")
+-//     try channel.closeFuture.wait()
+-// }
+-// catch {
+-//     print("Server error: \(error)")
+-//     exit(1)
+-// }
+-// print("Server closed")
 +// Bind the server to port 6379 and start accepting connections
-+let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
-+print("Server started and listening on \(channel.localAddress!)")
-+try channel.closeFuture.wait()
++do {
++    let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
++    print("Server started and listening on \(channel.localAddress!)")
++    try channel.closeFuture.wait()
++}
++catch {
++    print("Server error: \(error)")
++    exit(1)
++}
 +print("Server closed")

--- a/solutions/swift/02-rg2/code/Sources/main.swift
+++ b/solutions/swift/02-rg2/code/Sources/main.swift
@@ -22,7 +22,13 @@ let serverBootstrap = ServerBootstrap(group: group)
     }
 
 // Bind the server to port 6379 and start accepting connections
-let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
-print("Server started and listening on \(channel.localAddress!)")
-try channel.closeFuture.wait()
+do {
+    let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
+    print("Server started and listening on \(channel.localAddress!)")
+    try channel.closeFuture.wait()
+}
+catch {
+    print("Server error: \(error)")
+    exit(1)
+}
 print("Server closed")

--- a/solutions/swift/02-rg2/diff/Sources/main.swift.diff
+++ b/solutions/swift/02-rg2/diff/Sources/main.swift.diff
@@ -1,4 +1,4 @@
-@@ -1,26 +1,28 @@
+@@ -1,32 +1,34 @@
  import Foundation
  import NIO
 
@@ -23,7 +23,13 @@
      }
 
  // Bind the server to port 6379 and start accepting connections
- let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
- print("Server started and listening on \(channel.localAddress!)")
- try channel.closeFuture.wait()
+ do {
+     let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
+     print("Server started and listening on \(channel.localAddress!)")
+     try channel.closeFuture.wait()
+ }
+ catch {
+     print("Server error: \(error)")
+     exit(1)
+ }
  print("Server closed")

--- a/solutions/swift/03-wy1/code/Sources/main.swift
+++ b/solutions/swift/03-wy1/code/Sources/main.swift
@@ -29,7 +29,13 @@ let serverBootstrap = ServerBootstrap(group: group)
     }
 
 // Bind the server to port 6379 and start accepting connections
-let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
-print("Server started and listening on \(channel.localAddress!)")
-try channel.closeFuture.wait()
+do {
+    let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
+    print("Server started and listening on \(channel.localAddress!)")
+    try channel.closeFuture.wait()
+}
+catch {
+    print("Server error: \(error)")
+    exit(1)
+}
 print("Server closed")

--- a/solutions/swift/03-wy1/diff/Sources/main.swift.diff
+++ b/solutions/swift/03-wy1/diff/Sources/main.swift.diff
@@ -1,4 +1,4 @@
-@@ -1,28 +1,35 @@
+@@ -1,34 +1,41 @@
  import Foundation
  import NIO
 
@@ -34,7 +34,13 @@
      }
 
  // Bind the server to port 6379 and start accepting connections
- let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
- print("Server started and listening on \(channel.localAddress!)")
- try channel.closeFuture.wait()
+ do {
+     let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
+     print("Server started and listening on \(channel.localAddress!)")
+     try channel.closeFuture.wait()
+ }
+ catch {
+     print("Server error: \(error)")
+     exit(1)
+ }
  print("Server closed")

--- a/starter_templates/swift/code/Sources/main.swift
+++ b/starter_templates/swift/code/Sources/main.swift
@@ -23,8 +23,14 @@ let serverBootstrap = ServerBootstrap(group: group)
     }
 
 // Uncomment the code below to pass the first stage
-//// Bind the server to port 6379 and start accepting connections
-//let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "::1", port: 6379)).wait()
-//print("Server started and listening on \(channel.localAddress!)")
-//try channel.closeFuture.wait()
-//print("Server closed")
+// // Bind the server to port 6379 and start accepting connections
+// do {
+//     let channel = try serverBootstrap.bind(to: SocketAddress(ipAddress: "0.0.0.0", port: 6379)).wait()
+//     print("Server started and listening on \(channel.localAddress!)")
+//     try channel.closeFuture.wait()
+// }
+// catch {
+//     print("Server error: \(error)")
+//     exit(1)
+// }
+// print("Server closed")


### PR DESCRIPTION
This change addresses a crash that happens because the code was listening on IPv6 instead of IPv4.
- The base code now listens on IPv4 instead of IPv6, like other languages do.
- It also wraps the listener around a do/catch block to print the error and exit cleanly rather than crash due to an uncaught error.