### PR TITLE
Swift: actually cache dependency compilation across image builds

### DIFF
--- a/compiled_starters/swift/.codecrafters/compile.sh
+++ b/compiled_starters/swift/.codecrafters/compile.sh
@@ -20,3 +20,13 @@ set -e # Exit on failure
 .codecrafters/restore_mtimes.sh || true
 
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+
+# Snapshot the mtimes of all source and build files after a successful build.
+# The next build—possibly in a new container created from an image of this
+# one—restores them so it stays incremental.
+#
+# If the snapshot fails, proceed anyway: the worst case is a slower (but still
+# correct) next build.
+#
+# See the documentation in `snapshot_mtimes.sh` for more details.
+.codecrafters/snapshot_mtimes.sh || true

--- a/compiled_starters/swift/your_program.sh
+++ b/compiled_starters/swift/your_program.sh
@@ -16,6 +16,7 @@ set -e # Exit early if any commands fail
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   .codecrafters/restore_mtimes.sh || true
   swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+  .codecrafters/snapshot_mtimes.sh || true
 )
 
 # Copied from .codecrafters/run.sh

--- a/dockerfiles/swift-6.3.Dockerfile
+++ b/dockerfiles/swift-6.3.Dockerfile
@@ -6,15 +6,28 @@ ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Package.swift,Package.resolved"
 
 WORKDIR /app
 
+# Copy only the dependency manifests and build scripts first, so the expensive
+# dependency-build layer keyed on these files alone. Source-only changes then
+# reuse the cached layer instead of recompiling all dependencies.
+COPY Package.* /app/
+COPY .codecrafters /app/.codecrafters
+
+# Pre-build the dependencies (swift-nio etc.) against a stub source file. If
+# the stub doesn't match the package's target layout the build fails, which is
+# fine: compile.sh below will then do the full build instead.
+RUN (mkdir -p Sources \
+    && echo '// stub' > Sources/main.swift \
+    && swift build -c release --build-path /tmp/codecrafters-build-redis-swift) \
+    || true
+RUN rm -rf Sources
+
+# Snapshot mtimes so compile.sh's restore step can undo any mtime truncation
+# introduced when this layer is exported/restored (see snapshot_mtimes.sh).
+RUN .codecrafters/snapshot_mtimes.sh
+
 # .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
 COPY --exclude=.git --exclude=README.md . /app
 
+# This also refreshes the mtimes snapshot after building, so no separate
+# snapshot step is needed here.
 RUN .codecrafters/compile.sh
-
-# Snapshot the mtimes of all source files after a successful build. Their mtimes
-# will be restored before the next build in the container. This works around
-# some container backends that truncate mtimes, causing Swift's llbuild to
-# rebuild everything (no incremental builds).
-#
-# See the documentation in `snapshot_mtimes.sh` for more details.
-RUN .codecrafters/snapshot_mtimes.sh

--- a/solutions/swift/01-jm1/code/.codecrafters/compile.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/compile.sh
@@ -20,3 +20,13 @@ set -e # Exit on failure
 .codecrafters/restore_mtimes.sh || true
 
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+
+# Snapshot the mtimes of all source and build files after a successful build.
+# The next build—possibly in a new container created from an image of this
+# one—restores them so it stays incremental.
+#
+# If the snapshot fails, proceed anyway: the worst case is a slower (but still
+# correct) next build.
+#
+# See the documentation in `snapshot_mtimes.sh` for more details.
+.codecrafters/snapshot_mtimes.sh || true

--- a/solutions/swift/01-jm1/code/your_program.sh
+++ b/solutions/swift/01-jm1/code/your_program.sh
@@ -16,6 +16,7 @@ set -e # Exit early if any commands fail
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   .codecrafters/restore_mtimes.sh || true
   swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+  .codecrafters/snapshot_mtimes.sh || true
 )
 
 # Copied from .codecrafters/run.sh

--- a/solutions/swift/02-rg2/code/.codecrafters/compile.sh
+++ b/solutions/swift/02-rg2/code/.codecrafters/compile.sh
@@ -20,3 +20,13 @@ set -e # Exit on failure
 .codecrafters/restore_mtimes.sh || true
 
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+
+# Snapshot the mtimes of all source and build files after a successful build.
+# The next build—possibly in a new container created from an image of this
+# one—restores them so it stays incremental.
+#
+# If the snapshot fails, proceed anyway: the worst case is a slower (but still
+# correct) next build.
+#
+# See the documentation in `snapshot_mtimes.sh` for more details.
+.codecrafters/snapshot_mtimes.sh || true

--- a/solutions/swift/02-rg2/code/your_program.sh
+++ b/solutions/swift/02-rg2/code/your_program.sh
@@ -16,6 +16,7 @@ set -e # Exit early if any commands fail
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   .codecrafters/restore_mtimes.sh || true
   swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+  .codecrafters/snapshot_mtimes.sh || true
 )
 
 # Copied from .codecrafters/run.sh

--- a/solutions/swift/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/swift/03-wy1/code/.codecrafters/compile.sh
@@ -20,3 +20,13 @@ set -e # Exit on failure
 .codecrafters/restore_mtimes.sh || true
 
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+
+# Snapshot the mtimes of all source and build files after a successful build.
+# The next build—possibly in a new container created from an image of this
+# one—restores them so it stays incremental.
+#
+# If the snapshot fails, proceed anyway: the worst case is a slower (but still
+# correct) next build.
+#
+# See the documentation in `snapshot_mtimes.sh` for more details.
+.codecrafters/snapshot_mtimes.sh || true

--- a/solutions/swift/03-wy1/code/your_program.sh
+++ b/solutions/swift/03-wy1/code/your_program.sh
@@ -16,6 +16,7 @@ set -e # Exit early if any commands fail
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   .codecrafters/restore_mtimes.sh || true
   swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+  .codecrafters/snapshot_mtimes.sh || true
 )
 
 # Copied from .codecrafters/run.sh

--- a/starter_templates/swift/code/.codecrafters/compile.sh
+++ b/starter_templates/swift/code/.codecrafters/compile.sh
@@ -20,3 +20,13 @@ set -e # Exit on failure
 .codecrafters/restore_mtimes.sh || true
 
 swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+
+# Snapshot the mtimes of all source and build files after a successful build.
+# The next build—possibly in a new container created from an image of this
+# one—restores them so it stays incremental.
+#
+# If the snapshot fails, proceed anyway: the worst case is a slower (but still
+# correct) next build.
+#
+# See the documentation in `snapshot_mtimes.sh` for more details.
+.codecrafters/snapshot_mtimes.sh || true


### PR DESCRIPTION
Each CodeCrafters stage builds an image using the submission's source files, which represent the user's code at a different point of progress. So `docker build`, in the step `COPY . /app`, is handed a different set of files, and therefore always cache-missed, slowing things down, due to recompiling swift-nio and friends from scratch (~20s) on every stage and every submission.

This change splits the Dockerfile so the expensive dependency build is idempotent, and sits above the source copy (which is not idempotent):
  - `COPY` only `Package.*` and `.codecrafters` first
  - pre-build dependencies against a stub `Sources/main.swift`, into the same `--build-path` that `compile.sh` uses
  - snapshot mtimes, then COPY the real sources and run `compile.sh`

The dependency layer is now keyed only on the manifests, so it stays `CACHED` until `Package.swift` or `Package.resolved` change. The stub build is wrapped in `|| true`, so that a package whose target layout the stub doesn't fit (extra targets, custom paths, declared resources) just falls back to a full build in `compile.sh`, rather than failing the build completely.

---

I think #572 was only half of the puzzle, helping with the containers, and that we may end up requiring this change.

I noticed that even with #572  we were still getting some rebuilds, so I'm hoping this might help? It at least helped when running `course-sdk test swift`, but not sure how CodeCrafter' actual platform works. Thankfully, this is a pretty safe change anyway, so it would be good to see if that helps further.

Locally, `course-sdk test swift` is 3x faster thanks to no recompile whatsoever. Now even building images should be pretty snappy.

<table>
<tr>
<td>Before</td>
<td>

```shell
❯ time course-sdk test swift
[...]
course-sdk test swift  2.34s user 2.01s system 2% cpu 3:12.33 total
```

</td>
</tr>
<tr>
<td>After</td>
<td>

```shell
❯ time course-sdk test swift
[...]
course-sdk test swift  1.99s user 1.83s system 5% cpu 1:07.82 total
```

</td>
</tr>
</table>

Notice how the docker build steps went from ~20s (step `#11` in the "before") to ~1s (step `#16` in the "after")

<table>
<tr>
<td>Before</td>
<td>

```shell
❯ rg 'Build complete' course-sdk-test-swift-output-before.txt
198:     #11 20.14 Build complete! (19.75s)
401:     #11 19.35 Build complete! (19.08s)
437:     [compile] Build complete! (2.19s)
519:     [compile] Build complete! (2.52s)
633:     #11 19.56 Build complete! (19.30s)
669:     [compile] Build complete! (2.19s)
781:     #11 19.70 Build complete! (19.44s)
816:     [compile] Build complete! (2.31s)
939:     #11 20.83 Build complete! (20.57s)
974:     [compile] Build complete! (2.28s)
```

</td>
</tr>
<tr>
<td>After</td>
<td>

```shell
❯ rg 'Build complete' course-sdk-test-swift-output-after.txt
165:     #16 1.711 Build complete! (1.01s)
347:     #16 1.583 Build complete! (0.96s)
383:     [compile] Build complete! (2.52s)
465:     [compile] Build complete! (3.10s)
544:     #16 1.670 Build complete! (1.07s)
580:     [compile] Build complete! (1.52s)
656:     #16 1.718 Build complete! (1.12s)
692:     [compile] Build complete! (2.45s)
780:     #16 1.670 Build complete! (1.10s)
815:     [compile] Build complete! (2.31s)
```

</td>
</tr>
</table>

