### PR TITLE
Swift: keep test-run builds incremental by pinning the CPU count

### DIFF
--- a/compiled_starters/swift/.codecrafters/compile.sh
+++ b/compiled_starters/swift/.codecrafters/compile.sh
@@ -19,7 +19,11 @@ set -e # Exit on failure
 # development).
 .codecrafters/restore_mtimes.sh || true
 
-swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+# Build with a pinned CPU count so the Swift compile commands (and therefore
+# llbuild's command signatures) are identical between the image-build host and
+# the test runner, which have different core counts. Without this, every run
+# rebuilds the whole module graph. See swift_build.sh and cpushim.c.
+.codecrafters/swift_build.sh
 
 # Snapshot the mtimes of all source and build files after a successful build.
 # The next build—possibly in a new container created from an image of this

--- a/compiled_starters/swift/.codecrafters/cpushim.c
+++ b/compiled_starters/swift/.codecrafters/cpushim.c
@@ -1,0 +1,45 @@
+/*
+ * CPU-count shim (loaded via LD_PRELOAD by swift_build.sh).
+ *
+ * SwiftPM bakes the host's CPU count into every whole-module Swift compile
+ * command as `-num-threads <ProcessInfo.activeProcessorCount>` (and `-j`). The
+ * CodeCrafters image is built on a host with more cores than the test runner,
+ * so the command lines—and therefore llbuild's command signatures—differ
+ * between build and run. llbuild then considers every Swift command stale and
+ * rebuilds the entire module graph on each run (~30s). C targets compile via
+ * clang, for which SwiftPM doesn't use `-num-threads`, so they are spared from
+ * the issue.
+ *
+ * This shim overrides the CPU count lookups that SwiftPM reads
+ * (`activeProcessorCount` resolves to `sysconf(_SC_NPROCESSORS_ONLN)` on Linux)
+ * so that it always sees a constant count (FAKE_NPROC, default 4). The commands
+ * Swift PM emits then match in both environments (image build vs. test runner),
+ * and runs stay incremental. There is no SwiftPM/swiftc flag that pins
+ * `-num-threads`: it is appended unconditionally in the whole-module branch, so
+ * intercepting sysconf is the only lever that works.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+static int fake_nprocs(void) {
+    const char *env = getenv("FAKE_NPROC");
+    int num_cpus = env ? atoi(env) : 4;
+    return num_cpus > 0 ? num_cpus : 4;
+}
+
+static long (*real_sysconf)(int);
+
+long sysconf(int name) {
+    if (!real_sysconf) {
+        real_sysconf = dlsym(RTLD_NEXT, "sysconf");
+    }
+    if (name == _SC_NPROCESSORS_ONLN || name == _SC_NPROCESSORS_CONF) {
+        return fake_nprocs();
+    }
+    return real_sysconf(name);
+}
+
+int get_nprocs(void) { return fake_nprocs(); }
+int get_nprocs_conf(void) { return fake_nprocs(); }

--- a/compiled_starters/swift/.codecrafters/swift_build.sh
+++ b/compiled_starters/swift/.codecrafters/swift_build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Build the package with a pinned CPU count.
+#
+# SwiftPM bakes the host's CPU count into every whole-module Swift compile
+# command as `-num-threads`/`-j`. The CodeCrafters image is built on a host with
+# more cores than the test runner, so the command lines—and therefore llbuild's
+# command signatures—differ between build and run, forcing a full rebuild of the
+# whole module graph. LD_PRELOAD-ing a small shim (cpushim.c) makes SwiftPM read
+# a constant CPU count, so the commands (and signatures) are identical in both
+# places and runs stay incremental.
+#
+# This is invoked by BOTH compile.sh and the Dockerfile's dependency pre-build,
+# so they emit the same commands, and the build.db that ships matches what the
+# runner regenerates. See cpushim.c for why intercepting sysconf is the only
+# way to pin -num-threads.
+
+set -e
+
+# Pinned CPU count. Any constant keeps incremental builds deterministic across
+# different-core hosts; this value only affects build parallelism. 4 CPUs avoids
+# oversubscription on the test runners. If you need to speed up the infrequent
+# dependency/image builds, you can raise it toward the image-build host's core
+# count. Test runs remain incremental either way.
+NCPUS=4
+
+dir="$(dirname "$0")"
+SHIM=/tmp/codecrafters-cpushim.so
+# If this fails for any reason, fall back to a shim-less build (which is still
+# correct, it just won't have the incremental build optimisation across
+# different-core hosts).
+clang -shared -fPIC -o "$SHIM" "$dir/cpushim.c" -ldl 2>/dev/null || SHIM=""
+
+LD_PRELOAD="$SHIM" FAKE_NPROC="$NCPUS" \
+    swift build -c release --jobs "$NCPUS" --build-path /tmp/codecrafters-build-redis-swift

--- a/compiled_starters/swift/.codecrafters/swift_build.sh
+++ b/compiled_starters/swift/.codecrafters/swift_build.sh
@@ -22,7 +22,7 @@ set -e
 # oversubscription on the test runners. If you need to speed up the infrequent
 # dependency/image builds, you can raise it toward the image-build host's core
 # count. Test runs remain incremental either way.
-NCPUS=4
+NCPUS=1
 
 dir="$(dirname "$0")"
 SHIM=/tmp/codecrafters-cpushim.so

--- a/compiled_starters/swift/your_program.sh
+++ b/compiled_starters/swift/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   .codecrafters/restore_mtimes.sh || true
-  swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+  .codecrafters/swift_build.sh
   .codecrafters/snapshot_mtimes.sh || true
 )
 

--- a/dockerfiles/swift-6.3.Dockerfile
+++ b/dockerfiles/swift-6.3.Dockerfile
@@ -15,9 +15,14 @@ COPY .codecrafters /app/.codecrafters
 # Pre-build the dependencies (swift-nio etc.) against a stub source file. If
 # the stub doesn't match the package's target layout the build fails, which is
 # fine: compile.sh below will then do the full build instead.
+#
+# Use the same swift_build.sh as compile.sh (pinned CPU count), so this build
+# and the per-submit build emit identical compile commands. Without this,
+# Swift PM would re-derive the whole graph at a different core count, thereby
+# preventing incremental builds. See swift_build.sh / cpushim.c.
 RUN (mkdir -p Sources \
     && echo '// stub' > Sources/main.swift \
-    && swift build -c release --build-path /tmp/codecrafters-build-redis-swift) \
+    && .codecrafters/swift_build.sh) \
     || true
 RUN rm -rf Sources
 

--- a/solutions/swift/01-jm1/code/.codecrafters/compile.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/compile.sh
@@ -19,7 +19,11 @@ set -e # Exit on failure
 # development).
 .codecrafters/restore_mtimes.sh || true
 
-swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+# Build with a pinned CPU count so the Swift compile commands (and therefore
+# llbuild's command signatures) are identical between the image-build host and
+# the test runner, which have different core counts. Without this, every run
+# rebuilds the whole module graph. See swift_build.sh and cpushim.c.
+.codecrafters/swift_build.sh
 
 # Snapshot the mtimes of all source and build files after a successful build.
 # The next build—possibly in a new container created from an image of this

--- a/solutions/swift/01-jm1/code/.codecrafters/cpushim.c
+++ b/solutions/swift/01-jm1/code/.codecrafters/cpushim.c
@@ -1,0 +1,45 @@
+/*
+ * CPU-count shim (loaded via LD_PRELOAD by swift_build.sh).
+ *
+ * SwiftPM bakes the host's CPU count into every whole-module Swift compile
+ * command as `-num-threads <ProcessInfo.activeProcessorCount>` (and `-j`). The
+ * CodeCrafters image is built on a host with more cores than the test runner,
+ * so the command lines—and therefore llbuild's command signatures—differ
+ * between build and run. llbuild then considers every Swift command stale and
+ * rebuilds the entire module graph on each run (~30s). C targets compile via
+ * clang, for which SwiftPM doesn't use `-num-threads`, so they are spared from
+ * the issue.
+ *
+ * This shim overrides the CPU count lookups that SwiftPM reads
+ * (`activeProcessorCount` resolves to `sysconf(_SC_NPROCESSORS_ONLN)` on Linux)
+ * so that it always sees a constant count (FAKE_NPROC, default 4). The commands
+ * Swift PM emits then match in both environments (image build vs. test runner),
+ * and runs stay incremental. There is no SwiftPM/swiftc flag that pins
+ * `-num-threads`: it is appended unconditionally in the whole-module branch, so
+ * intercepting sysconf is the only lever that works.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+static int fake_nprocs(void) {
+    const char *env = getenv("FAKE_NPROC");
+    int num_cpus = env ? atoi(env) : 4;
+    return num_cpus > 0 ? num_cpus : 4;
+}
+
+static long (*real_sysconf)(int);
+
+long sysconf(int name) {
+    if (!real_sysconf) {
+        real_sysconf = dlsym(RTLD_NEXT, "sysconf");
+    }
+    if (name == _SC_NPROCESSORS_ONLN || name == _SC_NPROCESSORS_CONF) {
+        return fake_nprocs();
+    }
+    return real_sysconf(name);
+}
+
+int get_nprocs(void) { return fake_nprocs(); }
+int get_nprocs_conf(void) { return fake_nprocs(); }

--- a/solutions/swift/01-jm1/code/.codecrafters/swift_build.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/swift_build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Build the package with a pinned CPU count.
+#
+# SwiftPM bakes the host's CPU count into every whole-module Swift compile
+# command as `-num-threads`/`-j`. The CodeCrafters image is built on a host with
+# more cores than the test runner, so the command lines—and therefore llbuild's
+# command signatures—differ between build and run, forcing a full rebuild of the
+# whole module graph. LD_PRELOAD-ing a small shim (cpushim.c) makes SwiftPM read
+# a constant CPU count, so the commands (and signatures) are identical in both
+# places and runs stay incremental.
+#
+# This is invoked by BOTH compile.sh and the Dockerfile's dependency pre-build,
+# so they emit the same commands, and the build.db that ships matches what the
+# runner regenerates. See cpushim.c for why intercepting sysconf is the only
+# way to pin -num-threads.
+
+set -e
+
+# Pinned CPU count. Any constant keeps incremental builds deterministic across
+# different-core hosts; this value only affects build parallelism. 4 CPUs avoids
+# oversubscription on the test runners. If you need to speed up the infrequent
+# dependency/image builds, you can raise it toward the image-build host's core
+# count. Test runs remain incremental either way.
+NCPUS=4
+
+dir="$(dirname "$0")"
+SHIM=/tmp/codecrafters-cpushim.so
+# If this fails for any reason, fall back to a shim-less build (which is still
+# correct, it just won't have the incremental build optimisation across
+# different-core hosts).
+clang -shared -fPIC -o "$SHIM" "$dir/cpushim.c" -ldl 2>/dev/null || SHIM=""
+
+LD_PRELOAD="$SHIM" FAKE_NPROC="$NCPUS" \
+    swift build -c release --jobs "$NCPUS" --build-path /tmp/codecrafters-build-redis-swift

--- a/solutions/swift/01-jm1/code/.codecrafters/swift_build.sh
+++ b/solutions/swift/01-jm1/code/.codecrafters/swift_build.sh
@@ -22,7 +22,7 @@ set -e
 # oversubscription on the test runners. If you need to speed up the infrequent
 # dependency/image builds, you can raise it toward the image-build host's core
 # count. Test runs remain incremental either way.
-NCPUS=4
+NCPUS=1
 
 dir="$(dirname "$0")"
 SHIM=/tmp/codecrafters-cpushim.so

--- a/solutions/swift/01-jm1/code/your_program.sh
+++ b/solutions/swift/01-jm1/code/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   .codecrafters/restore_mtimes.sh || true
-  swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+  .codecrafters/swift_build.sh
   .codecrafters/snapshot_mtimes.sh || true
 )
 

--- a/solutions/swift/02-rg2/code/.codecrafters/compile.sh
+++ b/solutions/swift/02-rg2/code/.codecrafters/compile.sh
@@ -19,7 +19,11 @@ set -e # Exit on failure
 # development).
 .codecrafters/restore_mtimes.sh || true
 
-swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+# Build with a pinned CPU count so the Swift compile commands (and therefore
+# llbuild's command signatures) are identical between the image-build host and
+# the test runner, which have different core counts. Without this, every run
+# rebuilds the whole module graph. See swift_build.sh and cpushim.c.
+.codecrafters/swift_build.sh
 
 # Snapshot the mtimes of all source and build files after a successful build.
 # The next build—possibly in a new container created from an image of this

--- a/solutions/swift/02-rg2/code/.codecrafters/cpushim.c
+++ b/solutions/swift/02-rg2/code/.codecrafters/cpushim.c
@@ -1,0 +1,45 @@
+/*
+ * CPU-count shim (loaded via LD_PRELOAD by swift_build.sh).
+ *
+ * SwiftPM bakes the host's CPU count into every whole-module Swift compile
+ * command as `-num-threads <ProcessInfo.activeProcessorCount>` (and `-j`). The
+ * CodeCrafters image is built on a host with more cores than the test runner,
+ * so the command lines—and therefore llbuild's command signatures—differ
+ * between build and run. llbuild then considers every Swift command stale and
+ * rebuilds the entire module graph on each run (~30s). C targets compile via
+ * clang, for which SwiftPM doesn't use `-num-threads`, so they are spared from
+ * the issue.
+ *
+ * This shim overrides the CPU count lookups that SwiftPM reads
+ * (`activeProcessorCount` resolves to `sysconf(_SC_NPROCESSORS_ONLN)` on Linux)
+ * so that it always sees a constant count (FAKE_NPROC, default 4). The commands
+ * Swift PM emits then match in both environments (image build vs. test runner),
+ * and runs stay incremental. There is no SwiftPM/swiftc flag that pins
+ * `-num-threads`: it is appended unconditionally in the whole-module branch, so
+ * intercepting sysconf is the only lever that works.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+static int fake_nprocs(void) {
+    const char *env = getenv("FAKE_NPROC");
+    int num_cpus = env ? atoi(env) : 4;
+    return num_cpus > 0 ? num_cpus : 4;
+}
+
+static long (*real_sysconf)(int);
+
+long sysconf(int name) {
+    if (!real_sysconf) {
+        real_sysconf = dlsym(RTLD_NEXT, "sysconf");
+    }
+    if (name == _SC_NPROCESSORS_ONLN || name == _SC_NPROCESSORS_CONF) {
+        return fake_nprocs();
+    }
+    return real_sysconf(name);
+}
+
+int get_nprocs(void) { return fake_nprocs(); }
+int get_nprocs_conf(void) { return fake_nprocs(); }

--- a/solutions/swift/02-rg2/code/.codecrafters/swift_build.sh
+++ b/solutions/swift/02-rg2/code/.codecrafters/swift_build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Build the package with a pinned CPU count.
+#
+# SwiftPM bakes the host's CPU count into every whole-module Swift compile
+# command as `-num-threads`/`-j`. The CodeCrafters image is built on a host with
+# more cores than the test runner, so the command lines—and therefore llbuild's
+# command signatures—differ between build and run, forcing a full rebuild of the
+# whole module graph. LD_PRELOAD-ing a small shim (cpushim.c) makes SwiftPM read
+# a constant CPU count, so the commands (and signatures) are identical in both
+# places and runs stay incremental.
+#
+# This is invoked by BOTH compile.sh and the Dockerfile's dependency pre-build,
+# so they emit the same commands, and the build.db that ships matches what the
+# runner regenerates. See cpushim.c for why intercepting sysconf is the only
+# way to pin -num-threads.
+
+set -e
+
+# Pinned CPU count. Any constant keeps incremental builds deterministic across
+# different-core hosts; this value only affects build parallelism. 4 CPUs avoids
+# oversubscription on the test runners. If you need to speed up the infrequent
+# dependency/image builds, you can raise it toward the image-build host's core
+# count. Test runs remain incremental either way.
+NCPUS=4
+
+dir="$(dirname "$0")"
+SHIM=/tmp/codecrafters-cpushim.so
+# If this fails for any reason, fall back to a shim-less build (which is still
+# correct, it just won't have the incremental build optimisation across
+# different-core hosts).
+clang -shared -fPIC -o "$SHIM" "$dir/cpushim.c" -ldl 2>/dev/null || SHIM=""
+
+LD_PRELOAD="$SHIM" FAKE_NPROC="$NCPUS" \
+    swift build -c release --jobs "$NCPUS" --build-path /tmp/codecrafters-build-redis-swift

--- a/solutions/swift/02-rg2/code/.codecrafters/swift_build.sh
+++ b/solutions/swift/02-rg2/code/.codecrafters/swift_build.sh
@@ -22,7 +22,7 @@ set -e
 # oversubscription on the test runners. If you need to speed up the infrequent
 # dependency/image builds, you can raise it toward the image-build host's core
 # count. Test runs remain incremental either way.
-NCPUS=4
+NCPUS=1
 
 dir="$(dirname "$0")"
 SHIM=/tmp/codecrafters-cpushim.so

--- a/solutions/swift/02-rg2/code/your_program.sh
+++ b/solutions/swift/02-rg2/code/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   .codecrafters/restore_mtimes.sh || true
-  swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+  .codecrafters/swift_build.sh
   .codecrafters/snapshot_mtimes.sh || true
 )
 

--- a/solutions/swift/03-wy1/code/.codecrafters/compile.sh
+++ b/solutions/swift/03-wy1/code/.codecrafters/compile.sh
@@ -19,7 +19,11 @@ set -e # Exit on failure
 # development).
 .codecrafters/restore_mtimes.sh || true
 
-swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+# Build with a pinned CPU count so the Swift compile commands (and therefore
+# llbuild's command signatures) are identical between the image-build host and
+# the test runner, which have different core counts. Without this, every run
+# rebuilds the whole module graph. See swift_build.sh and cpushim.c.
+.codecrafters/swift_build.sh
 
 # Snapshot the mtimes of all source and build files after a successful build.
 # The next build—possibly in a new container created from an image of this

--- a/solutions/swift/03-wy1/code/.codecrafters/cpushim.c
+++ b/solutions/swift/03-wy1/code/.codecrafters/cpushim.c
@@ -1,0 +1,45 @@
+/*
+ * CPU-count shim (loaded via LD_PRELOAD by swift_build.sh).
+ *
+ * SwiftPM bakes the host's CPU count into every whole-module Swift compile
+ * command as `-num-threads <ProcessInfo.activeProcessorCount>` (and `-j`). The
+ * CodeCrafters image is built on a host with more cores than the test runner,
+ * so the command lines—and therefore llbuild's command signatures—differ
+ * between build and run. llbuild then considers every Swift command stale and
+ * rebuilds the entire module graph on each run (~30s). C targets compile via
+ * clang, for which SwiftPM doesn't use `-num-threads`, so they are spared from
+ * the issue.
+ *
+ * This shim overrides the CPU count lookups that SwiftPM reads
+ * (`activeProcessorCount` resolves to `sysconf(_SC_NPROCESSORS_ONLN)` on Linux)
+ * so that it always sees a constant count (FAKE_NPROC, default 4). The commands
+ * Swift PM emits then match in both environments (image build vs. test runner),
+ * and runs stay incremental. There is no SwiftPM/swiftc flag that pins
+ * `-num-threads`: it is appended unconditionally in the whole-module branch, so
+ * intercepting sysconf is the only lever that works.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+static int fake_nprocs(void) {
+    const char *env = getenv("FAKE_NPROC");
+    int num_cpus = env ? atoi(env) : 4;
+    return num_cpus > 0 ? num_cpus : 4;
+}
+
+static long (*real_sysconf)(int);
+
+long sysconf(int name) {
+    if (!real_sysconf) {
+        real_sysconf = dlsym(RTLD_NEXT, "sysconf");
+    }
+    if (name == _SC_NPROCESSORS_ONLN || name == _SC_NPROCESSORS_CONF) {
+        return fake_nprocs();
+    }
+    return real_sysconf(name);
+}
+
+int get_nprocs(void) { return fake_nprocs(); }
+int get_nprocs_conf(void) { return fake_nprocs(); }

--- a/solutions/swift/03-wy1/code/.codecrafters/swift_build.sh
+++ b/solutions/swift/03-wy1/code/.codecrafters/swift_build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Build the package with a pinned CPU count.
+#
+# SwiftPM bakes the host's CPU count into every whole-module Swift compile
+# command as `-num-threads`/`-j`. The CodeCrafters image is built on a host with
+# more cores than the test runner, so the command lines—and therefore llbuild's
+# command signatures—differ between build and run, forcing a full rebuild of the
+# whole module graph. LD_PRELOAD-ing a small shim (cpushim.c) makes SwiftPM read
+# a constant CPU count, so the commands (and signatures) are identical in both
+# places and runs stay incremental.
+#
+# This is invoked by BOTH compile.sh and the Dockerfile's dependency pre-build,
+# so they emit the same commands, and the build.db that ships matches what the
+# runner regenerates. See cpushim.c for why intercepting sysconf is the only
+# way to pin -num-threads.
+
+set -e
+
+# Pinned CPU count. Any constant keeps incremental builds deterministic across
+# different-core hosts; this value only affects build parallelism. 4 CPUs avoids
+# oversubscription on the test runners. If you need to speed up the infrequent
+# dependency/image builds, you can raise it toward the image-build host's core
+# count. Test runs remain incremental either way.
+NCPUS=4
+
+dir="$(dirname "$0")"
+SHIM=/tmp/codecrafters-cpushim.so
+# If this fails for any reason, fall back to a shim-less build (which is still
+# correct, it just won't have the incremental build optimisation across
+# different-core hosts).
+clang -shared -fPIC -o "$SHIM" "$dir/cpushim.c" -ldl 2>/dev/null || SHIM=""
+
+LD_PRELOAD="$SHIM" FAKE_NPROC="$NCPUS" \
+    swift build -c release --jobs "$NCPUS" --build-path /tmp/codecrafters-build-redis-swift

--- a/solutions/swift/03-wy1/code/.codecrafters/swift_build.sh
+++ b/solutions/swift/03-wy1/code/.codecrafters/swift_build.sh
@@ -22,7 +22,7 @@ set -e
 # oversubscription on the test runners. If you need to speed up the infrequent
 # dependency/image builds, you can raise it toward the image-build host's core
 # count. Test runs remain incremental either way.
-NCPUS=4
+NCPUS=1
 
 dir="$(dirname "$0")"
 SHIM=/tmp/codecrafters-cpushim.so

--- a/solutions/swift/03-wy1/code/your_program.sh
+++ b/solutions/swift/03-wy1/code/your_program.sh
@@ -15,7 +15,7 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   .codecrafters/restore_mtimes.sh || true
-  swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+  .codecrafters/swift_build.sh
   .codecrafters/snapshot_mtimes.sh || true
 )
 

--- a/starter_templates/swift/code/.codecrafters/compile.sh
+++ b/starter_templates/swift/code/.codecrafters/compile.sh
@@ -19,7 +19,11 @@ set -e # Exit on failure
 # development).
 .codecrafters/restore_mtimes.sh || true
 
-swift build -c release --build-path /tmp/codecrafters-build-redis-swift
+# Build with a pinned CPU count so the Swift compile commands (and therefore
+# llbuild's command signatures) are identical between the image-build host and
+# the test runner, which have different core counts. Without this, every run
+# rebuilds the whole module graph. See swift_build.sh and cpushim.c.
+.codecrafters/swift_build.sh
 
 # Snapshot the mtimes of all source and build files after a successful build.
 # The next build—possibly in a new container created from an image of this

--- a/starter_templates/swift/code/.codecrafters/cpushim.c
+++ b/starter_templates/swift/code/.codecrafters/cpushim.c
@@ -1,0 +1,45 @@
+/*
+ * CPU-count shim (loaded via LD_PRELOAD by swift_build.sh).
+ *
+ * SwiftPM bakes the host's CPU count into every whole-module Swift compile
+ * command as `-num-threads <ProcessInfo.activeProcessorCount>` (and `-j`). The
+ * CodeCrafters image is built on a host with more cores than the test runner,
+ * so the command lines—and therefore llbuild's command signatures—differ
+ * between build and run. llbuild then considers every Swift command stale and
+ * rebuilds the entire module graph on each run (~30s). C targets compile via
+ * clang, for which SwiftPM doesn't use `-num-threads`, so they are spared from
+ * the issue.
+ *
+ * This shim overrides the CPU count lookups that SwiftPM reads
+ * (`activeProcessorCount` resolves to `sysconf(_SC_NPROCESSORS_ONLN)` on Linux)
+ * so that it always sees a constant count (FAKE_NPROC, default 4). The commands
+ * Swift PM emits then match in both environments (image build vs. test runner),
+ * and runs stay incremental. There is no SwiftPM/swiftc flag that pins
+ * `-num-threads`: it is appended unconditionally in the whole-module branch, so
+ * intercepting sysconf is the only lever that works.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+static int fake_nprocs(void) {
+    const char *env = getenv("FAKE_NPROC");
+    int num_cpus = env ? atoi(env) : 4;
+    return num_cpus > 0 ? num_cpus : 4;
+}
+
+static long (*real_sysconf)(int);
+
+long sysconf(int name) {
+    if (!real_sysconf) {
+        real_sysconf = dlsym(RTLD_NEXT, "sysconf");
+    }
+    if (name == _SC_NPROCESSORS_ONLN || name == _SC_NPROCESSORS_CONF) {
+        return fake_nprocs();
+    }
+    return real_sysconf(name);
+}
+
+int get_nprocs(void) { return fake_nprocs(); }
+int get_nprocs_conf(void) { return fake_nprocs(); }

--- a/starter_templates/swift/code/.codecrafters/swift_build.sh
+++ b/starter_templates/swift/code/.codecrafters/swift_build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Build the package with a pinned CPU count.
+#
+# SwiftPM bakes the host's CPU count into every whole-module Swift compile
+# command as `-num-threads`/`-j`. The CodeCrafters image is built on a host with
+# more cores than the test runner, so the command lines—and therefore llbuild's
+# command signatures—differ between build and run, forcing a full rebuild of the
+# whole module graph. LD_PRELOAD-ing a small shim (cpushim.c) makes SwiftPM read
+# a constant CPU count, so the commands (and signatures) are identical in both
+# places and runs stay incremental.
+#
+# This is invoked by BOTH compile.sh and the Dockerfile's dependency pre-build,
+# so they emit the same commands, and the build.db that ships matches what the
+# runner regenerates. See cpushim.c for why intercepting sysconf is the only
+# way to pin -num-threads.
+
+set -e
+
+# Pinned CPU count. Any constant keeps incremental builds deterministic across
+# different-core hosts; this value only affects build parallelism. 4 CPUs avoids
+# oversubscription on the test runners. If you need to speed up the infrequent
+# dependency/image builds, you can raise it toward the image-build host's core
+# count. Test runs remain incremental either way.
+NCPUS=4
+
+dir="$(dirname "$0")"
+SHIM=/tmp/codecrafters-cpushim.so
+# If this fails for any reason, fall back to a shim-less build (which is still
+# correct, it just won't have the incremental build optimisation across
+# different-core hosts).
+clang -shared -fPIC -o "$SHIM" "$dir/cpushim.c" -ldl 2>/dev/null || SHIM=""
+
+LD_PRELOAD="$SHIM" FAKE_NPROC="$NCPUS" \
+    swift build -c release --jobs "$NCPUS" --build-path /tmp/codecrafters-build-redis-swift

--- a/starter_templates/swift/code/.codecrafters/swift_build.sh
+++ b/starter_templates/swift/code/.codecrafters/swift_build.sh
@@ -22,7 +22,7 @@ set -e
 # oversubscription on the test runners. If you need to speed up the infrequent
 # dependency/image builds, you can raise it toward the image-build host's core
 # count. Test runs remain incremental either way.
-NCPUS=4
+NCPUS=1
 
 dir="$(dirname "$0")"
 SHIM=/tmp/codecrafters-cpushim.so


### PR DESCRIPTION
SwiftPM appends the host CPU core count to every whole-module Swift compile command as `-num-threads <activeProcessorCount>` (and `-j`). CodeCrafters builds the image on a host with more cores than the test runner, so the command lines—and therefore llbuild's command signatures—differ between the build.db that ships in the image and the plan the runner regenerates. llbuild marks every Swift command stale and rebuilds the whole dependency graph (swift-nio, ...) on each run (~30s). C targets compile via clang, for which SwiftPM doesn't use `-num-threads`, so they are spared from the issue.

This change pins the CPU count that SwiftPM reads to a constant via an `LD_PRELOAD` shim (`cpushim.c`) which overrides `sysconf(_SC_NPROCESSORS_*)`. `swift_build.sh` applies it (with a matching `--jobs N`) and is used by BOTH the Dockerfile's dependency pre-build and the per-submit `compile.sh`, so they emit identical commands and the signatures match across build and run. No SwiftPM/swiftc flag pins `-num-threads` (it is appended unconditionally in the whole-module branch), so intercepting sysconf is the only lever.

This was confirmed end-to-end: a cold test run drops from ~28s to ~1s.

This change is additional to the existing mtime snapshot/restore work, which fixes a separate sub-second mtime truncation issue, which remains needed.

#575 is probably still useful to keep as well. But this CPU finding explains why I wasn't reproducing locally: both the image builder and the test runner were running on the same machine (my Mac).

## Alternatives considered

Ultimately, this change is required due to the fact that the machines building the images have a different CPU counts, and that Swift PM doesn't like this for some reason.

Therefore, another possibility could be to add a setting in `compiled_starters/swift/codecrafters.yml` to require "same amount of CPU", accepting that this may slow down the first image build. That could be a cleaner than using LD_PRELOAD, but is something I believe I don't have access to change.

## Verification

I was able to verify this change by checking out my Redis Swift repo locally, and then:
- Making a comment change to Package.swift, to re-triggering an image build
- Adding the files being changed here
- Triggering `codecrafters submit`

Result:

```
❯ codecrafters submit
Submitting changes (commit: 47815e7)...

⚡ This is a turbo test run. https://codecrafters.io/turbo

Running tests on your code. Logs should appear shortly...

Detected changes to Package.swift. Re-building... (this might take a while)

[build] Starting build...
[...]
[build] > Fetching https://github.com/apple/swift-atomics.git
[build] > Fetching https://github.com/apple/swift-system.git
[...]
[build] > Building for production...
[build] > [0/23] Write sources
[build] > [11/23] Compiling CNIOWindows WSAStartup.c
[...]
[build] > Build complete! (24.15s)
[build] Step 16 complete.
[build] Step 17 complete.
[build] > Created mtimes snapshot at /tmp/codecrafters-mtimes.snapshot
[build] Step 18 complete.
[build] Step 19 complete.
[build] > Restored mtimes: restored=2261 missing=0 failed=0 time_taken=8s
[build] > [0/1] Planning build
[build] > Building for production...
[build] > [0/3] Write sources
[...]
[build] > Build complete! (18.85s)
[build] > Created mtimes snapshot at /tmp/codecrafters-mtimes.snapshot
[build] Step 20 complete.
[build] Step 21 complete.
[build] Step 22 complete.
[build] Step 23 complete.
[build] Step 24 complete.
[build] Build successful.

[compile] Restored mtimes: restored=2278 missing=6 failed=0 time_taken=5s
[compile] [0/1] Planning build
[compile] Building for production...
[compile] [0/2] Write swift-version-24593BA9C3E375BF.txt
[compile] Build complete! (1.08s)
[compile] Created mtimes snapshot at /tmp/codecrafters-mtimes.snapshot
[compile] Moved ./.codecrafters/run.sh → ./your_program.sh
[compile] Compilation successful.

[tester::#JM1] Running tests for Stage #JM1 (Bind to a port)
[...]
```

Then a subsequent run a few seconds or minutes later:

```
❯ codecrafters submit
Submitting changes (commit: 301e0ba)...

⚡ This is a turbo test run. https://codecrafters.io/turbo

Running tests on your code. Logs should appear shortly...

[compile] Restored mtimes: restored=2278 missing=6 failed=0 time_taken=2s
[compile] [0/1] Planning build
[compile] Building for production...
[compile] [0/2] Write swift-version-24593BA9C3E375BF.txt
[compile] Build complete! (1.09s)
[compile] Created mtimes snapshot at /tmp/codecrafters-mtimes.snapshot
[compile] Moved ./.codecrafters/run.sh → ./your_program.sh
[compile] Compilation successful.

[tester::#JM1] Running tests for Stage #JM1 (Bind to a port)
[...]
```