### PR TITLE
CC-2281: Upgrade Rust to v1.96

### DIFF
--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/dockerfiles/rust-1.96.Dockerfile
+++ b/dockerfiles/rust-1.96.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.96-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-jm1/code/README.md
+++ b/solutions/rust/01-jm1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-jm1/code/codecrafters.yml
+++ b/solutions/rust/01-jm1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/solutions/rust/02-rg2/code/README.md
+++ b/solutions/rust/02-rg2/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/02-rg2/code/codecrafters.yml
+++ b/solutions/rust/02-rg2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/solutions/rust/03-wy1/code/README.md
+++ b/solutions/rust/03-wy1/code/README.md
@@ -26,7 +26,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.95)` installed locally
+1. Ensure you have `cargo (1.96)` installed locally
 1. Run `./your_program.sh` to run your Redis server, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/03-wy1/code/codecrafters.yml
+++ b/solutions/rust/03-wy1/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.95
-buildpack: rust-1.95
+# Available versions: rust-1.96
+buildpack: rust-1.96

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.95)
+  required_executable: cargo (1.96)
   user_editable_file: src/main.rs


### PR DESCRIPTION
CC-2281: Upgrade Rust to v1.96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and documentation updates only; no application logic or security-sensitive code changes.
> 
> **Overview**
> Bumps the CodeCrafters Rust track from **1.95** to **1.96** across starter templates, compiled starters, and bundled solution copies.
> 
> **Runtime/build:** Adds `dockerfiles/rust-1.96.Dockerfile` (`rust:1.96-trixie`, same compile flow as prior Rust images) and switches `buildpack` in `codecrafters.yml` to `rust-1.96`. **Docs/config:** README “Stage 2 & beyond” now requires `cargo (1.96)`; `starter_templates/rust/config.yml` updates `required_executable` to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38daa67e3482b84c188771415ef72d3f8ff8d75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->